### PR TITLE
CUDA: always specify the architecture of targetted gpu to nvrtc (even for older cuda version)

### DIFF
--- a/vkFFT/vkFFT.h
+++ b/vkFFT/vkFFT.h
@@ -35090,7 +35090,6 @@ static inline VkFFTResult VkFFTPlanR2CMultiUploadDecomposition(VkFFTApplication*
 				deleteVkFFT(app);
 				return VKFFT_ERROR_FAILED_TO_CREATE_PROGRAM;
 			}
-#if (CUDA_VERSION >= 11030)
 			char* opts[5];
 			opts[0] = (char*)malloc(sizeof(char) * 50);
 			if (!opts[0]) {
@@ -35099,18 +35098,17 @@ static inline VkFFTResult VkFFTPlanR2CMultiUploadDecomposition(VkFFTApplication*
 				deleteVkFFT(app);
 				return VKFFT_ERROR_MALLOC_FAILED;
 			}
+#if (CUDA_VERSION >= 11030)
 			sprintf(opts[0], "--gpu-architecture=sm_%" PRIu64 "%" PRIu64 "", app->configuration.computeCapabilityMajor, app->configuration.computeCapabilityMinor);
+#else
+			sprintf(opts[0], "--gpu-architecture=compute_%" PRIu64 "%" PRIu64 "", app->configuration.computeCapabilityMajor, app->configuration.computeCapabilityMinor);
+#endif
 			//result = nvrtcAddNameExpression(prog, "&consts");
 			//if (result != NVRTC_SUCCESS) printf("1.5 error: %s\n", nvrtcGetErrorString(result));
 			result = nvrtcCompileProgram(prog,  // prog
 				1,     // numOptions
 				(const char* const*)opts); // options
 			free(opts[0]);
-#else
-			result = nvrtcCompileProgram(prog,  // prog
-				0,     // numOptions
-				0); // options
-#endif
 			if (result != NVRTC_SUCCESS) {
 				printf("nvrtcCompileProgram error: %s\n", nvrtcGetErrorString(result));
 				char* log = (char*)malloc(sizeof(char) * 4000000);


### PR DESCRIPTION
For CUDA_VERSION < 11030, vkFFT does not specify an architecture, such that an old one is chosen, possibly leading to suboptimal PTX code.
This PR fixes it by specifying a (virtual) architecture to generate the best possible PTX code.

I'm not sure it has a sensible effect on the performance, but for sure it can't be worse.

As a side comment/question, I'm not sure fetching a CUBIN (for CUDA_VERSION >= 11030) instead of a PTX has any advantage. Why are you doing it this way?