### PR TITLE
Fix clang compilation errors (`develop` branch)

### DIFF
--- a/vkFFT/vkFFT.h
+++ b/vkFFT/vkFFT.h
@@ -58,6 +58,12 @@
 #endif
 #endif
 
+#ifdef __cplusplus
+#define ZERO_INIT {}
+#else
+#define ZERO_INIT {0}
+#endif
+
 #include "vkFFT_Structs/vkFFT_Structs.h"
 #include "vkFFT_AppManagement/vkFFT_RunApp.h"
 #include "vkFFT_AppManagement/vkFFT_InitializeApp.h"

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h
@@ -60,9 +60,9 @@ static inline void appendBluesteinMultiplication(VkFFTSpecializationConstantsLay
 	VkContainer localSize = {};
 	localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
+	VkContainer* localInvocationID = {0};
 	
-	VkContainer* batching_localInvocationID = {};
+	VkContainer* batching_localInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		localSize.data.i = sc->localSize[1].data.i;
@@ -214,7 +214,7 @@ static inline void appendBluesteinConvolution(VkFFTSpecializationConstantsLayout
 	VkContainer localSize = {};
 	localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
+	VkContainer* localInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		localSize.data.i = sc->localSize[1].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h
@@ -60,9 +60,9 @@ static inline void appendBluesteinMultiplication(VkFFTSpecializationConstantsLay
 	VkContainer localSize = {};
 	localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
 	
-	VkContainer* batching_localInvocationID = {0};
+	VkContainer* batching_localInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		localSize.data.i = sc->localSize[1].data.i;
@@ -214,7 +214,7 @@ static inline void appendBluesteinConvolution(VkFFTSpecializationConstantsLayout
 	VkContainer localSize = {};
 	localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		localSize.data.i = sc->localSize[1].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
@@ -45,7 +45,7 @@ static inline void appendRegisterStorage(VkFFTSpecializationConstantsLayout* sc,
 	VkContainer localSize = {};
 	localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
+	VkContainer* localInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		localSize.data.i = sc->localSize[1].data.i;
@@ -137,8 +137,8 @@ static inline void appendKernelConvolution(VkFFTSpecializationConstantsLayout* s
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
@@ -45,7 +45,7 @@ static inline void appendRegisterStorage(VkFFTSpecializationConstantsLayout* sc,
 	VkContainer localSize = {};
 	localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		localSize.data.i = sc->localSize[1].data.i;
@@ -137,8 +137,8 @@ static inline void appendKernelConvolution(VkFFTSpecializationConstantsLayout* s
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h
@@ -48,8 +48,8 @@ static inline void appendC2R_read(VkFFTSpecializationConstantsLayout* sc, int ty
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -308,8 +308,8 @@ static inline void appendR2C_write(VkFFTSpecializationConstantsLayout* sc, int t
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h
@@ -48,8 +48,8 @@ static inline void appendC2R_read(VkFFTSpecializationConstantsLayout* sc, int ty
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -308,8 +308,8 @@ static inline void appendR2C_write(VkFFTSpecializationConstantsLayout* sc, int t
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2R.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2R.h
@@ -46,8 +46,8 @@ static inline void appendDCTI_read(VkFFTSpecializationConstantsLayout* sc, int t
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -201,8 +201,8 @@ static inline void appendDCTII_read_III_write(VkFFTSpecializationConstantsLayout
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -372,8 +372,8 @@ static inline void appendDCTII_write_III_read(VkFFTSpecializationConstantsLayout
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -636,8 +636,8 @@ static inline void appendDCTIV_even_read(VkFFTSpecializationConstantsLayout* sc,
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -1251,8 +1251,8 @@ static inline void appendDCTIV_even_write(VkFFTSpecializationConstantsLayout* sc
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -1520,8 +1520,8 @@ static inline void appendDCTIV_odd_read(VkFFTSpecializationConstantsLayout* sc, 
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -1799,8 +1799,8 @@ static inline void appendDCTIV_odd_write(VkFFTSpecializationConstantsLayout* sc,
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2R.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2R.h
@@ -46,8 +46,8 @@ static inline void appendDCTI_read(VkFFTSpecializationConstantsLayout* sc, int t
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -201,8 +201,8 @@ static inline void appendDCTII_read_III_write(VkFFTSpecializationConstantsLayout
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -372,8 +372,8 @@ static inline void appendDCTII_write_III_read(VkFFTSpecializationConstantsLayout
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -636,8 +636,8 @@ static inline void appendDCTIV_even_read(VkFFTSpecializationConstantsLayout* sc,
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -1251,8 +1251,8 @@ static inline void appendDCTIV_even_write(VkFFTSpecializationConstantsLayout* sc
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -1520,8 +1520,8 @@ static inline void appendDCTIV_odd_read(VkFFTSpecializationConstantsLayout* sc, 
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;
@@ -1799,8 +1799,8 @@ static inline void appendDCTIV_odd_write(VkFFTSpecializationConstantsLayout* sc,
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RaderKernels.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RaderKernels.h
@@ -80,7 +80,7 @@ static inline void appendFFTRaderStage(VkFFTSpecializationConstantsLayout* sc, V
 	}
 	//rotate the stage
 
-	VkContainer* localInvocationID = {};
+	VkContainer* localInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		localInvocationID = &sc->gl_LocalInvocationID_y;
@@ -1332,7 +1332,7 @@ static inline void appendMultRaderStage(VkFFTSpecializationConstantsLayout* sc, 
 	int64_t require_cutoff_check = ((sc->fftDim.data.i == (num_logical_subgroups * num_logical_groups.data.i * stageRadix->data.i))) ? 0 : 1;
 	int64_t require_cutoff_check2;
 	
-	VkContainer* localInvocationID = {};
+	VkContainer* localInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		localInvocationID = &sc->gl_LocalInvocationID_y;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RaderKernels.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RaderKernels.h
@@ -80,7 +80,7 @@ static inline void appendFFTRaderStage(VkFFTSpecializationConstantsLayout* sc, V
 	}
 	//rotate the stage
 
-	VkContainer* localInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		localInvocationID = &sc->gl_LocalInvocationID_y;
@@ -1332,7 +1332,7 @@ static inline void appendMultRaderStage(VkFFTSpecializationConstantsLayout* sc, 
 	int64_t require_cutoff_check = ((sc->fftDim.data.i == (num_logical_subgroups * num_logical_groups.data.i * stageRadix->data.i))) ? 0 : 1;
 	int64_t require_cutoff_check2;
 	
-	VkContainer* localInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		localInvocationID = &sc->gl_LocalInvocationID_y;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
@@ -399,8 +399,8 @@ static inline void appendReadWriteDataVkFFT_nonstrided(VkFFTSpecializationConsta
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
@@ -399,8 +399,8 @@ static inline void appendReadWriteDataVkFFT_nonstrided(VkFFTSpecializationConsta
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RegisterBoost.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RegisterBoost.h
@@ -43,8 +43,8 @@ static inline void appendBoostThreadDataReorder(VkFFTSpecializationConstantsLayo
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {};
-	VkContainer* batchingInvocationID = {};
+	VkContainer* localInvocationID = {0};
+	VkContainer* batchingInvocationID = {0};
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RegisterBoost.h
+++ b/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_RegisterBoost.h
@@ -43,8 +43,8 @@ static inline void appendBoostThreadDataReorder(VkFFTSpecializationConstantsLayo
 	VkContainer batching_localSize = {};
 	batching_localSize.type = 31;
 
-	VkContainer* localInvocationID = {0};
-	VkContainer* batchingInvocationID = {0};
+	VkContainer* localInvocationID = ZERO_INIT;
+	VkContainer* batchingInvocationID = ZERO_INIT;
 
 	if (sc->stridedSharedLayout) {
 		batching_localSize.data.i = sc->localSize[0].data.i;

--- a/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
+++ b/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
@@ -336,7 +336,7 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 				commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 				commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 				commandBufferAllocateInfo.commandBufferCount = 1;
-				VkCommandBuffer commandBuffer = {0};
+				VkCommandBuffer commandBuffer = ZERO_INIT;
 				res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 				if (res != 0) {
 					free(phaseVectors);
@@ -561,7 +561,7 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 			commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 			commandBufferAllocateInfo.commandBufferCount = 1;
-			VkCommandBuffer commandBuffer = {0};
+			VkCommandBuffer commandBuffer = ZERO_INIT;
 			res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 			if (res != 0) {
 				free(phaseVectors);
@@ -621,7 +621,7 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 			commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 			commandBufferAllocateInfo.commandBufferCount = 1;
-			VkCommandBuffer commandBuffer = {0};
+			VkCommandBuffer commandBuffer = ZERO_INIT;
 			res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 			if (res != 0) {
 				free(phaseVectors);
@@ -1098,7 +1098,7 @@ static inline VkFFTResult VkFFTGenerateRaderFFTKernel(VkFFTApplication* app, VkF
 					commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 					commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 					commandBufferAllocateInfo.commandBufferCount = 1;
-					VkCommandBuffer commandBuffer = {0};
+					VkCommandBuffer commandBuffer = ZERO_INIT;
 					res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 					if (res != 0) {
 						free(axis->specializationConstants.raderContainer[i].raderFFTkernel);

--- a/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
+++ b/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
@@ -336,7 +336,7 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 				commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 				commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 				commandBufferAllocateInfo.commandBufferCount = 1;
-				VkCommandBuffer commandBuffer = {};
+				VkCommandBuffer commandBuffer = {0};
 				res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 				if (res != 0) {
 					free(phaseVectors);
@@ -561,7 +561,7 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 			commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 			commandBufferAllocateInfo.commandBufferCount = 1;
-			VkCommandBuffer commandBuffer = {};
+			VkCommandBuffer commandBuffer = {0};
 			res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 			if (res != 0) {
 				free(phaseVectors);
@@ -621,7 +621,7 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 			commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 			commandBufferAllocateInfo.commandBufferCount = 1;
-			VkCommandBuffer commandBuffer = {};
+			VkCommandBuffer commandBuffer = {0};
 			res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 			if (res != 0) {
 				free(phaseVectors);
@@ -1098,7 +1098,7 @@ static inline VkFFTResult VkFFTGenerateRaderFFTKernel(VkFFTApplication* app, VkF
 					commandBufferAllocateInfo.commandPool = kernelPreparationApplication.configuration.commandPool[0];
 					commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 					commandBufferAllocateInfo.commandBufferCount = 1;
-					VkCommandBuffer commandBuffer = {};
+					VkCommandBuffer commandBuffer = {0};
 					res = vkAllocateCommandBuffers(kernelPreparationApplication.configuration.device[0], &commandBufferAllocateInfo, &commandBuffer);
 					if (res != 0) {
 						free(axis->specializationConstants.raderContainer[i].raderFFTkernel);

--- a/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -67,13 +67,13 @@
 #endif
 
 //unified VkFFT container
-union VkData {
+typedef union VkData {
 	int64_t i;
 	long double d;
 	long double c[2];
 
 	char* s;
-};
+} VkData;
 typedef struct VkContainer VkContainer;
 struct VkContainer{
 	int type; // 0 - uninitialized


### PR DESCRIPTION
Hi! I've been writing VkFFT bindings for Rust recently, which requires that everything compiles okay with `clang` (in C mode, not C++ mode). I received the following errors when I tried to compile the library and so I went and made the neccesary changes.

When compiled with `clang vkFFT/vkFFT.h -I /usr/include/glslang/Include/ -I vkFFT/`:

```
In file included from vkFFT/vkFFT.h:61:
vkFFT/vkFFT_Structs/vkFFT_Structs.h:84:2: error: must use 'union' tag to refer to type 'VkData'
        VkData data; // memory of the container
        ^
        union 
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:26:
vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h:339:37: error: scalar initializer cannot be empty
                                VkCommandBuffer commandBuffer = {};
                                                                ^~
vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h:564:36: error: scalar initializer cannot be empty
                        VkCommandBuffer commandBuffer = {};
                                                        ^~
vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h:624:36: error: scalar initializer cannot be empty
                        VkCommandBuffer commandBuffer = {};
                                                        ^~
vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h:1101:38: error: scalar initializer cannot be empty
                                        VkCommandBuffer commandBuffer = {};
                                                                        ^~
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:27:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_InitAPIParameters.h:26:
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6599:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil((long double)in_1->data.i / in_2->data.d));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6603:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil((long double)in_1->data.i / in_2->data.c[0]));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6611:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.d / (long double)in_2->data.i));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6615:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.d / in_2->data.d));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6619:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.d / in_2->data.c[0]));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6627:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.c[0] / (long double)in_2->data.i));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6631:51: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                        sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.c[0] / in_2->data.d));
                                                                            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6732:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil((long double)in_1->data.i / in_2->data.d));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6736:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil((long double)in_1->data.i / in_2->data.c[1]));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6744:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.d / (long double)in_2->data.i));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6748:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.d / in_2->data.d));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6752:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.d / in_2->data.c[1]));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6760:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.c[1] / (long double)in_2->data.i));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:6764:52: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
                                                sc->tempLen = sprintf(sc->tempStr, "%.17Le", ceil(in_1->data.c[1] / in_2->data.d));
                                                                                    ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                    %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:7389:33: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
%s.x = %.17Le;\n", out->data.s, cos(in_1->data.d));
       ~~~~~~                   ^~~~~~~~~~~~~~~~~
       %.17e
vkFFT/vkFFT_CodeGen/vkFFT_MathUtils/vkFFT_MathUtils.h:7392:33: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
%s.y = %.17Le;\n", out->data.s, sin(in_1->data.d));
       ~~~~~~                   ^~~~~~~~~~~~~~~~~
       %.17e
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:31:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel2/vkFFT_FFT.h:28:
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel0/vkFFT_MemoryManagement/vkFFT_MemoryInitialization/vkFFT_InputOutputLayout.h:229:8: warning: format specifies type 'int' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
};\n", loc_id, vecType->data.s);
       ^~~~~~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel0/vkFFT_MemoryManagement/vkFFT_MemoryInitialization/vkFFT_InputOutputLayout.h:237:8: warning: format specifies type 'int' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
};\n", loc_id, vecType->data.s);
       ^~~~~~
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:31:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel2/vkFFT_FFT.h:35:
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h:63:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h:65:44: error: scalar initializer cannot be empty
        VkContainer* batching_localInvocationID = {};
                                                  ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Bluestein.h:217:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:31:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel2/vkFFT_FFT.h:36:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h:32:
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h:402:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h:403:38: error: scalar initializer cannot be empty
        VkContainer* batchingInvocationID = {};
                                            ^~
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:31:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel2/vkFFT_FFT.h:36:
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h:48:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h:140:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h:141:38: error: scalar initializer cannot be empty
        VkContainer* batchingInvocationID = {};
                                            ^~
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:31:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel2/vkFFT_FFT.h:37:
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h:51:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h:52:38: error: scalar initializer cannot be empty
        VkContainer* batchingInvocationID = {};
                                            ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h:311:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2C.h:312:38: error: scalar initializer cannot be empty
        VkContainer* batchingInvocationID = {};
                                            ^~
In file included from vkFFT/vkFFT.h:63:
In file included from vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h:30:
In file included from vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h:31:
In file included from vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel2/vkFFT_FFT.h:38:
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2R.h:49:35: error: scalar initializer cannot be empty
        VkContainer* localInvocationID = {};
                                         ^~
vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_R2R.h:50:38: error: scalar initializer cannot be empty
        VkContainer* batchingInvocationID = {};
                                            ^~
fatal error: too many errors emitted, stopping now [-ferror-limit=]
18 warnings and 20 errors generated.

```