### PR TITLE
Add NULL pointer check to deleteVkFFT

### DIFF
--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h
@@ -26,6 +26,9 @@
 #include "vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_UpdateBuffers.h"
 
 static inline void deleteVkFFT(VkFFTApplication* app) {
+	if (app == NULL) {
+		return;
+	}
 #if(VKFFT_BACKEND==0)
 	if (app->configuration.isCompilerInitialized) {
 		glslang_finalize_process();


### PR DESCRIPTION
Copy behaviour of e. g. `free` and `fftw_plan_destroy`, where deleting null pointer does nothing instead of segmentation fault.