### PR TITLE
Async multistream synchronization for CUDA and HIP backends

### DIFF
--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -543,7 +543,6 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.device = inputLaunchConfiguration.device;
 	if (inputLaunchConfiguration.num_streams != 0)	app->configuration.num_streams = inputLaunchConfiguration.num_streams;
 	if (inputLaunchConfiguration.stream != 0)	app->configuration.stream = inputLaunchConfiguration.stream;
-	app->configuration.streamID = 0;
 	int value = 0;
 	res = cuDeviceGetAttribute(&value, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, app->configuration.device[0]);
 	if (res != CUDA_SUCCESS) {
@@ -659,7 +658,6 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.device = inputLaunchConfiguration.device;
 	if (inputLaunchConfiguration.num_streams != 0)	app->configuration.num_streams = inputLaunchConfiguration.num_streams;
 	if (inputLaunchConfiguration.stream != 0)	app->configuration.stream = inputLaunchConfiguration.stream;
-	app->configuration.streamID = 0;
 	int value = 0;
 	res = hipDeviceGetAttribute(&value, hipDeviceAttributeComputeCapabilityMajor, app->configuration.device[0]);
 	if (res != hipSuccess) {

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -634,7 +634,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
 		for (pfUINT i = 0; i < app->configuration.num_streams; i++) {
-			res_t = cudaEventCreate(&app->configuration.stream_event[i]);
+			res_t = cudaEventCreateWithFlags(&app->configuration.stream_event[i], cudaEventDisableTiming);
 			if (res_t != cudaSuccess) {
 				deleteVkFFT(app);
 				return VKFFT_ERROR_FAILED_TO_CREATE_EVENT;
@@ -738,7 +738,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
 		for (pfUINT i = 0; i < app->configuration.num_streams; i++) {
-			res = hipEventCreate(&app->configuration.stream_event[i]);
+			res = hipEventCreateWithFlags(&app->configuration.stream_event[i], hipEventDisableTiming);
 			if (res != hipSuccess) {
 				deleteVkFFT(app);
 				return VKFFT_ERROR_FAILED_TO_CREATE_EVENT;

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -310,12 +310,8 @@ typedef struct {
 	VkMemoryBarrier* memory_barrier;//Filled at app creation
 #elif(VKFFT_BACKEND==1)
 	cudaEvent_t* stream_event;//Filled at app creation
-	pfUINT streamCounter;//Filled at app creation
-	pfUINT streamID;//Filled at app creation
 #elif(VKFFT_BACKEND==2)
 	hipEvent_t* stream_event;//Filled at app creation
-	pfUINT streamCounter;//Filled at app creation
-	pfUINT streamID;//Filled at app creation
 	pfINT  useStrict32BitAddress; // guarantee 32 bit addresses in bytes instead of number of elements. This results in fewer instructions generated. -1: Disable, 0: Infer based on size, 1: enable. Has no effect with useUint64.
 #elif(VKFFT_BACKEND==3)
 	cl_command_queue* commandQueue;


### PR DESCRIPTION
This commit should fix #163.

#### Changes
1. `InitializeApp`
     - removed `streamID` variable initialization
3. `RunApp`
    - function `VkFFTSync` does nothing now for CUDA and HIP
    - added *pre* and *post* synchronization in `VkFFTAppend` function as proposed in issue
    - removed `streamCounter` variable initialization
4. `DispatchPlan`
    - kernels are launched to either `0` stream or `app->configuration.stream[0]` if some streams were passed
    - removed event recording completely
5. `Structs`
    - removed `streamCounter` and `streamID` members from CUDA and HIP configuration