### PR TITLE
Use enum for vendor id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if(build_VkFFT_FFTW_precision)
 		benchmark_scripts/vkFFT_scripts/src/sample_50_convolution_VkFFT_single_1d_matrix.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_51_convolution_VkFFT_single_3d_matrix_zeropadding_r2c.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_52_convolution_VkFFT_single_2d_batched_r2c.cpp
+		benchmark_scripts/vkFFT_scripts/src/sample_53_convolution_VkFFT_single_2d_Nimages_1kernel.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_100_benchmark_VkFFT_single_nd_dct.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_101_benchmark_VkFFT_double_nd_dct.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_1000_benchmark_VkFFT_single_2_4096.cpp
@@ -85,6 +86,7 @@ else()
 		benchmark_scripts/vkFFT_scripts/src/sample_50_convolution_VkFFT_single_1d_matrix.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_51_convolution_VkFFT_single_3d_matrix_zeropadding_r2c.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_52_convolution_VkFFT_single_2d_batched_r2c.cpp
+		benchmark_scripts/vkFFT_scripts/src/sample_53_convolution_VkFFT_single_2d_Nimages_1kernel.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_100_benchmark_VkFFT_single_nd_dct.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_101_benchmark_VkFFT_double_nd_dct.cpp
 		benchmark_scripts/vkFFT_scripts/src/sample_1000_benchmark_VkFFT_single_2_4096.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,19 +156,21 @@ if(VkFFT_use_FP128_double_double)
 	target_link_libraries(${PROJECT_NAME} PUBLIC quadmath)
 endif()
 if(${VKFFT_BACKEND} EQUAL 0)
-	set(ENABLE_OPT 0)
-	FetchContent_Declare(
-		glslang-main
-		GIT_TAG ${GLSLANG_GIT_TAG}
-		GIT_REPOSITORY https://github.com/KhronosGroup/glslang
-		SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/glslang-main
-	)
-	FetchContent_GetProperties(glslang-main)
-	if(NOT glslang-main_POPULATED)
-		FetchContent_Populate(glslang-main)
-	endif()
-	target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/glslang-main/glslang/Include/)
-	add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/glslang-main)
+	find_package(glslang CONFIG)
+	if (NOT ${glslang_FOUND})
+		set(ENABLE_OPT 0)
+		FetchContent_Declare(
+			glslang-main
+			GIT_TAG ${GLSLANG_GIT_TAG}
+			GIT_REPOSITORY https://github.com/KhronosGroup/glslang
+			SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/glslang-main
+		)
+		FetchContent_GetProperties(glslang-main)
+		if(NOT glslang-main_POPULATED)
+			FetchContent_Populate(glslang-main)
+		endif()
+		add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/glslang-main)
+	endif (NOT ${glslang_FOUND})
 endif()
 
 add_library(VkFFT INTERFACE)
@@ -181,7 +183,11 @@ target_include_directories(half INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/half_lib/)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_scripts/vkFFT_scripts/include/)
 
 if(${VKFFT_BACKEND} EQUAL 0)
-	target_link_libraries(${PROJECT_NAME} PUBLIC SPIRV glslang Vulkan::Vulkan VkFFT half)
+	if (${glslang_FOUND})
+		target_link_libraries(${PROJECT_NAME} PUBLIC glslang::SPIRV glslang::glslang Vulkan::Vulkan VkFFT half)
+	else (${glslang_FOUND})
+		target_link_libraries(${PROJECT_NAME} PUBLIC SPIRV glslang Vulkan::Vulkan VkFFT half)
+	endif (${glslang_FOUND})
 elseif(${VKFFT_BACKEND} EQUAL 1)
 	find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
 	add_definitions(-DCUDA_TOOLKIT_ROOT_DIR="${CUDA_TOOLKIT_ROOT_DIR}")

--- a/VkFFT_TestSuite.cpp
+++ b/VkFFT_TestSuite.cpp
@@ -9,7 +9,7 @@
 #include <inttypes.h>
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/VkFFT_TestSuite.cpp
+++ b/VkFFT_TestSuite.cpp
@@ -82,6 +82,7 @@
 #include "sample_50_convolution_VkFFT_single_1d_matrix.h"
 #include "sample_51_convolution_VkFFT_single_3d_matrix_zeropadding_r2c.h"
 #include "sample_52_convolution_VkFFT_single_2d_batched_r2c.h"
+#include "sample_53_convolution_VkFFT_single_2d_Nimages_1kernel.h"
 
 #include "sample_100_benchmark_VkFFT_single_nd_dct.h"
 #include "sample_101_benchmark_VkFFT_double_nd_dct.h"
@@ -424,6 +425,11 @@ VkFFTResult launchVkFFT(VkGPU* vkGPU, uint64_t sample_id, bool file_output, FILE
         resFFT = sample_52_convolution_VkFFT_single_2d_batched_r2c(vkGPU, file_output, output, isCompilerInitialized);
         break;
     }
+	case 53:
+    {
+        resFFT = sample_53_convolution_VkFFT_single_2d_Nimages_1kernel(vkGPU, file_output, output, isCompilerInitialized);
+        break;
+    }
     case 110:
     {
         resFFT = sample_100_benchmark_VkFFT_single_nd_dct(vkGPU, file_output, output, isCompilerInitialized, 1);
@@ -638,6 +644,7 @@ int main(int argc, char* argv[])
 		printf("		50 - convolution example with identity kernel\n");
 		printf("		51 - zeropadding convolution example with identity kernel\n");
 		printf("		52 - batched convolution example with identity kernel\n");
+		printf("		53 - convolution example with one scaling kernel of three colors, multiple images of three colors\n");
 		printf("		110 - VkFFT FFT + iFFT R2R DCT-1 multidimensional benchmark in single precision\n");
 		printf("		111 - VkFFT FFT + iFFT R2R DCT-1 multidimensional benchmark in double precision\n");
 		printf("		120 - VkFFT FFT + iFFT R2R DCT-2 multidimensional benchmark in single precision\n");

--- a/benchmark_scripts/vkFFT_scripts/include/sample_53_convolution_VkFFT_single_2d_Nimages_1kernel.h
+++ b/benchmark_scripts/vkFFT_scripts/include/sample_53_convolution_VkFFT_single_2d_Nimages_1kernel.h
@@ -1,0 +1,4 @@
+#include "vkFFT.h"
+#include "utils_VkFFT.h"
+
+VkFFTResult sample_53_convolution_VkFFT_single_2d_Nimages_1kernel(VkGPU* vkGPU, uint64_t file_output, FILE* output, uint64_t isCompilerInitialized);

--- a/benchmark_scripts/vkFFT_scripts/src/sample_0_benchmark_VkFFT_single.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_0_benchmark_VkFFT_single.cpp
@@ -201,16 +201,16 @@ VkFFTResult sample_0_benchmark_VkFFT_single(VkGPU* vkGPU, uint64_t file_output, 
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)(((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize);
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_0_benchmark_VkFFT_single.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_0_benchmark_VkFFT_single.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1000_benchmark_VkFFT_single_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1000_benchmark_VkFFT_single_2_4096.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1000_benchmark_VkFFT_single_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1000_benchmark_VkFFT_single_2_4096.cpp
@@ -213,16 +213,16 @@ VkFFTResult sample_1000_benchmark_VkFFT_single_2_4096(VkGPU* vkGPU, uint64_t fil
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1001_benchmark_VkFFT_double_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1001_benchmark_VkFFT_double_2_4096.cpp
@@ -216,16 +216,16 @@ VkFFTResult sample_1001_benchmark_VkFFT_double_2_4096(VkGPU* vkGPU, uint64_t fil
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1001_benchmark_VkFFT_double_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1001_benchmark_VkFFT_double_2_4096.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1002_benchmark_VkFFT_half_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1002_benchmark_VkFFT_half_2_4096.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1002_benchmark_VkFFT_half_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1002_benchmark_VkFFT_half_2_4096.cpp
@@ -215,16 +215,16 @@ VkFFTResult sample_1002_benchmark_VkFFT_half_2_4096(VkGPU* vkGPU, uint64_t file_
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1003_benchmark_VkFFT_single_3d_2_512.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1003_benchmark_VkFFT_single_3d_2_512.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1003_benchmark_VkFFT_single_3d_2_512.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1003_benchmark_VkFFT_single_3d_2_512.cpp
@@ -212,16 +212,16 @@ VkFFTResult sample_1003_benchmark_VkFFT_single_3d_2_512(VkGPU* vkGPU, uint64_t f
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1004_benchmark_VkFFT_quadDoubleDouble_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1004_benchmark_VkFFT_quadDoubleDouble_2_4096.cpp
@@ -216,16 +216,16 @@ VkFFTResult sample_1004_benchmark_VkFFT_quadDoubleDouble_2_4096(VkGPU* vkGPU, ui
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1004_benchmark_VkFFT_quadDoubleDouble_2_4096.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1004_benchmark_VkFFT_quadDoubleDouble_2_4096.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_100_benchmark_VkFFT_single_nd_dct.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_100_benchmark_VkFFT_single_nd_dct.cpp
@@ -239,16 +239,16 @@ VkFFTResult sample_100_benchmark_VkFFT_single_nd_dct(VkGPU* vkGPU, uint64_t file
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_100_benchmark_VkFFT_single_nd_dct.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_100_benchmark_VkFFT_single_nd_dct.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_101_benchmark_VkFFT_double_nd_dct.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_101_benchmark_VkFFT_double_nd_dct.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_101_benchmark_VkFFT_double_nd_dct.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_101_benchmark_VkFFT_double_nd_dct.cpp
@@ -240,16 +240,16 @@ VkFFTResult sample_101_benchmark_VkFFT_double_nd_dct(VkGPU* vkGPU, uint64_t file
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_10_benchmark_VkFFT_single_multipleBuffers.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_10_benchmark_VkFFT_single_multipleBuffers.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_10_benchmark_VkFFT_single_multipleBuffers.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_10_benchmark_VkFFT_single_multipleBuffers.cpp
@@ -198,9 +198,9 @@ VkFFTResult sample_10_benchmark_VkFFT_single_multipleBuffers(VkGPU* vkGPU, uint6
 
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / (numBuf * bufferSize[0]) > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / (numBuf * bufferSize[0]);
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 			if (num_iter == 0) num_iter = 1;
-			if (vkGPU->physicalDeviceProperties.vendorID != 0x8086) num_iter *= 5;
+			if (vkGPU->physicalDeviceProperties.vendorID != VKFFT_VENDOR_INTEL) num_iter *= 5;
 			double totTime = 0;
 			VkFFTLaunchParams launchParams = {};
 			resFFT = performVulkanFFTiFFT(vkGPU, &app, &launchParams, num_iter, &totTime);

--- a/benchmark_scripts/vkFFT_scripts/src/sample_11_precision_VkFFT_single.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_11_precision_VkFFT_single.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_12_precision_VkFFT_double.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_12_precision_VkFFT_double.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_13_precision_VkFFT_half.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_13_precision_VkFFT_half.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_14_precision_VkFFT_single_nonPow2.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_14_precision_VkFFT_single_nonPow2.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_15_precision_VkFFT_single_r2c.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_15_precision_VkFFT_single_r2c.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_16_precision_VkFFT_single_dct.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_16_precision_VkFFT_single_dct.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_17_precision_VkFFT_double_dct.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_17_precision_VkFFT_double_dct.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_18_precision_VkFFT_double_nonPow2.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_18_precision_VkFFT_double_nonPow2.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_19_precision_VkFFT_quadDoubleDouble_nonPow2.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_19_precision_VkFFT_quadDoubleDouble_nonPow2.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1_benchmark_VkFFT_double.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1_benchmark_VkFFT_double.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_1_benchmark_VkFFT_double.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_1_benchmark_VkFFT_double.cpp
@@ -206,16 +206,16 @@ VkFFTResult sample_1_benchmark_VkFFT_double(VkGPU* vkGPU, uint64_t file_output, 
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_2_benchmark_VkFFT_half.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_2_benchmark_VkFFT_half.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_2_benchmark_VkFFT_half.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_2_benchmark_VkFFT_half.cpp
@@ -95,7 +95,7 @@ VkFFTResult sample_2_benchmark_VkFFT_half(VkGPU* vkGPU, uint64_t file_output, FI
 
 			//PARAMETERS THAT CAN BE ADJUSTED FOR SPECIFIC GPU's - this configuration is by no means final form
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) {
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) {
 				if (n > 22)//128byte coalescing has a limit of 2^24 max size
 					configuration.coalescedMemory = 64;
 				else
@@ -104,7 +104,7 @@ VkFFTResult sample_2_benchmark_VkFFT_half(VkGPU* vkGPU, uint64_t file_output, FI
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) {
+			if (vendorID == VKFFT_VENDOR_INTEL) {
 				if (n > 22)//128byte coalescing has a limit of 2^24 max size
 					configuration.coalescedMemory = 64;
 				else
@@ -114,7 +114,7 @@ VkFFTResult sample_2_benchmark_VkFFT_half(VkGPU* vkGPU, uint64_t file_output, FI
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) {
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) {
 				if (n > 22)//128byte coalescing has a limit of 2^24 max size
 					configuration.coalescedMemory = 64;
 				else
@@ -236,11 +236,11 @@ VkFFTResult sample_2_benchmark_VkFFT_half(VkGPU* vkGPU, uint64_t file_output, FI
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
-			if (vendorID == 0x8086) num_iter /= 4;
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==4)
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_3_benchmark_VkFFT_single_3d.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_3_benchmark_VkFFT_single_3d.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_3_benchmark_VkFFT_single_3d.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_3_benchmark_VkFFT_single_3d.cpp
@@ -211,16 +211,16 @@ VkFFTResult sample_3_benchmark_VkFFT_single_3d(VkGPU* vkGPU, uint64_t file_outpu
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_4_benchmark_VkFFT_single_3d_zeropadding.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_4_benchmark_VkFFT_single_3d_zeropadding.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_4_benchmark_VkFFT_single_3d_zeropadding.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_4_benchmark_VkFFT_single_3d_zeropadding.cpp
@@ -222,16 +222,16 @@ VkFFTResult sample_4_benchmark_VkFFT_single_3d_zeropadding(VkGPU* vkGPU, uint64_
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_50_convolution_VkFFT_single_1d_matrix.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_50_convolution_VkFFT_single_1d_matrix.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_51_convolution_VkFFT_single_3d_matrix_zeropadding_r2c.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_51_convolution_VkFFT_single_3d_matrix_zeropadding_r2c.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_52_convolution_VkFFT_single_2d_batched_r2c.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_52_convolution_VkFFT_single_2d_batched_r2c.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_5_benchmark_VkFFT_single_disableReorderFourStep.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_5_benchmark_VkFFT_single_disableReorderFourStep.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_5_benchmark_VkFFT_single_disableReorderFourStep.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_5_benchmark_VkFFT_single_disableReorderFourStep.cpp
@@ -206,16 +206,16 @@ VkFFTResult sample_5_benchmark_VkFFT_single_disableReorderFourStep(VkGPU* vkGPU,
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)3 * 4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_6_benchmark_VkFFT_single_r2c.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_6_benchmark_VkFFT_single_r2c.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_6_benchmark_VkFFT_single_r2c.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_6_benchmark_VkFFT_single_r2c.cpp
@@ -205,16 +205,16 @@ VkFFTResult sample_6_benchmark_VkFFT_single_r2c(VkGPU* vkGPU, uint64_t file_outp
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 

--- a/benchmark_scripts/vkFFT_scripts/src/sample_7_benchmark_VkFFT_single_Bluestein.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_7_benchmark_VkFFT_single_Bluestein.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_7_benchmark_VkFFT_single_Bluestein.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_7_benchmark_VkFFT_single_Bluestein.cpp
@@ -206,16 +206,16 @@ VkFFTResult sample_7_benchmark_VkFFT_single_Bluestein(VkGPU* vkGPU, uint64_t fil
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_8_benchmark_VkFFT_double_Bluestein.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_8_benchmark_VkFFT_double_Bluestein.cpp
@@ -207,16 +207,16 @@ VkFFTResult sample_8_benchmark_VkFFT_double_Bluestein(VkGPU* vkGPU, uint64_t fil
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/sample_8_benchmark_VkFFT_double_Bluestein.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_8_benchmark_VkFFT_double_Bluestein.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_9_benchmark_VkFFT_quadDoubleDouble.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_9_benchmark_VkFFT_quadDoubleDouble.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/sample_9_benchmark_VkFFT_quadDoubleDouble.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/sample_9_benchmark_VkFFT_quadDoubleDouble.cpp
@@ -206,16 +206,16 @@ VkFFTResult sample_9_benchmark_VkFFT_quadDoubleDouble(VkGPU* vkGPU, uint64_t fil
 			//Submit FFT+iFFT.
 			uint64_t num_iter = (((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize > 1000) ? 1000 : (uint64_t)((uint64_t)4096 * 1024.0 * 1024.0) / bufferSize;
 #if(VKFFT_BACKEND==0)
-			if (vkGPU->physicalDeviceProperties.vendorID == 0x8086) num_iter /= 4;
+			if (vkGPU->physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;
 #elif(VKFFT_BACKEND==3)
 			cl_uint vendorID;
 			clGetDeviceInfo(vkGPU->device, CL_DEVICE_VENDOR_ID, sizeof(cl_int), &vendorID, 0);
-			if (vendorID == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (vendorID == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #elif(VKFFT_BACKEND==4)
 			ze_device_properties_t device_properties;
 			res = zeDeviceGetProperties(vkGPU->device, &device_properties);
 			if (res != 0) return VKFFT_ERROR_FAILED_TO_GET_ATTRIBUTE;
-			if (device_properties.vendorId == 0x8086) num_iter /= 4;//smaller benchmark for Intel GPUs
+			if (device_properties.vendorId == VKFFT_VENDOR_INTEL) num_iter /= 4;//smaller benchmark for Intel GPUs
 #endif
 			if (num_iter == 0) num_iter = 1;
 			double totTime = 0;

--- a/benchmark_scripts/vkFFT_scripts/src/user_benchmark_VkFFT.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/user_benchmark_VkFFT.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark_scripts/vkFFT_scripts/src/utils_VkFFT.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/utils_VkFFT.cpp
@@ -13,7 +13,7 @@
 
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/vkFFT/vkFFT.h
+++ b/vkFFT/vkFFT.h
@@ -35,7 +35,7 @@
 #include <inttypes.h>
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <nvrtc.h>
 #include <cuda.h>

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h
@@ -26,7 +26,7 @@
 #include "vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_UpdateBuffers.h"
 
 static inline void deleteVkFFT(VkFFTApplication* app) {
-	if (app == NULL) {
+	if (app == 0) {
 		return;
 	}
 #if(VKFFT_BACKEND==0)

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h
@@ -26,6 +26,9 @@
 #include "vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_UpdateBuffers.h"
 
 static inline void deleteVkFFT(VkFFTApplication* app) {
+	if (app == NULL) {
+		return;
+	}
 #if(VKFFT_BACKEND==0)
 	if (app->configuration.isCompilerInitialized) {
 		glslang_finalize_process();

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -478,6 +478,8 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	}
 	app->configuration.fence = inputLaunchConfiguration.fence;
 
+	app->configuration.usePushDescriptors = inputLaunchConfiguration.usePushDescriptors;
+
 	VkPhysicalDeviceProperties physicalDeviceProperties = { 0 };
 	vkGetPhysicalDeviceProperties(app->configuration.physicalDevice[0], &physicalDeviceProperties);
 	app->configuration.maxThreadsNum = physicalDeviceProperties.limits.maxComputeWorkGroupInvocations;

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -1176,56 +1176,6 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	if (inputLaunchConfiguration.kernelOffset != 0)	app->configuration.kernelOffset = inputLaunchConfiguration.kernelOffset;
 	if (inputLaunchConfiguration.specifyOffsetsAtLaunch != 0)	app->configuration.specifyOffsetsAtLaunch = inputLaunchConfiguration.specifyOffsetsAtLaunch;
 	//set optional parameters:
-	pfUINT checkBufferSizeFor64BitAddressing = 0;
-	for (pfUINT i = 0; i < app->configuration.bufferNum; i++) {
-		if (app->configuration.bufferSize)
-			checkBufferSizeFor64BitAddressing += app->configuration.bufferSize[i];
-		else {
-			checkBufferSizeFor64BitAddressing = app->configuration.size[0] * app->configuration.size[1] * app->configuration.size[2] * 8;
-			if (app->configuration.coordinateFeatures > 0) checkBufferSizeFor64BitAddressing *= app->configuration.coordinateFeatures;
-			if (app->configuration.numberBatches > 0) checkBufferSizeFor64BitAddressing *= app->configuration.numberBatches;
-			if (app->configuration.numberKernels > 0) checkBufferSizeFor64BitAddressing *= app->configuration.numberKernels;
-			if (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) checkBufferSizeFor64BitAddressing *= 2;
-			if (app->configuration.quadDoubleDoublePrecision) checkBufferSizeFor64BitAddressing *= 4;
-		}
-	}
-#if(VKFFT_BACKEND==2)
-	app->configuration.useStrict32BitAddress = 0;
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)32)) app->configuration.useStrict32BitAddress = -1;
-#endif
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
-	checkBufferSizeFor64BitAddressing = 0;
-	for (pfUINT i = 0; i < app->configuration.inputBufferNum; i++) {
-		if (app->configuration.inputBufferSize)
-			checkBufferSizeFor64BitAddressing += app->configuration.inputBufferSize[i];
-	}
-#if(VKFFT_BACKEND==2)
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)32)) app->configuration.useStrict32BitAddress = -1;
-#endif
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
-
-	checkBufferSizeFor64BitAddressing = 0;
-	for (pfUINT i = 0; i < app->configuration.outputBufferNum; i++) {
-		if (app->configuration.outputBufferSize)
-			checkBufferSizeFor64BitAddressing += app->configuration.outputBufferSize[i];
-	}
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
-
-	checkBufferSizeFor64BitAddressing = 0;
-	for (pfUINT i = 0; i < app->configuration.kernelNum; i++) {
-		if (app->configuration.kernelSize)
-			checkBufferSizeFor64BitAddressing += app->configuration.kernelSize[i];
-	}
-#if(VKFFT_BACKEND==2)
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)32)) app->configuration.useStrict32BitAddress = -1;
-	// No reason was found to disable strict 32 bit addressing, so enable it
-	if (app->configuration.useStrict32BitAddress == 0) app->configuration.useStrict32BitAddress = 1;
-#endif
-	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
-	if (inputLaunchConfiguration.useUint64 != 0)	app->configuration.useUint64 = inputLaunchConfiguration.useUint64;
-#if(VKFFT_BACKEND==2)
-	if (inputLaunchConfiguration.useStrict32BitAddress != 0) app->configuration.useStrict32BitAddress = inputLaunchConfiguration.useStrict32BitAddress;
-#endif
 	if (inputLaunchConfiguration.maxThreadsNum != 0)	app->configuration.maxThreadsNum = inputLaunchConfiguration.maxThreadsNum;
 	if (inputLaunchConfiguration.coalescedMemory != 0)	app->configuration.coalescedMemory = inputLaunchConfiguration.coalescedMemory;
 	app->configuration.aimThreads = 128;
@@ -1380,7 +1330,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 
 		if (inputLaunchConfiguration.matrixConvolution != 0)	app->configuration.matrixConvolution = inputLaunchConfiguration.matrixConvolution;
 		if (inputLaunchConfiguration.numberKernels != 0)	app->configuration.numberKernels = inputLaunchConfiguration.numberKernels;
-
+		if (inputLaunchConfiguration.singleKernelMultipleBatches != 0)	app->configuration.singleKernelMultipleBatches = inputLaunchConfiguration.singleKernelMultipleBatches;
 		if (inputLaunchConfiguration.symmetricKernel != 0)	app->configuration.symmetricKernel = inputLaunchConfiguration.symmetricKernel;
 		if (inputLaunchConfiguration.conjugateConvolution != 0)	app->configuration.conjugateConvolution = inputLaunchConfiguration.conjugateConvolution;
 		if (inputLaunchConfiguration.crossPowerSpectrumNormalization != 0)	app->configuration.crossPowerSpectrumNormalization = inputLaunchConfiguration.crossPowerSpectrumNormalization;
@@ -1391,6 +1341,58 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 		app->configuration.registerBoost4Step = 1;
 		if (app->configuration.matrixConvolution > 1) app->configuration.coordinateFeatures = app->configuration.matrixConvolution;
 	}
+
+	pfUINT checkBufferSizeFor64BitAddressing = 0;
+	for (pfUINT i = 0; i < app->configuration.bufferNum; i++) {
+		if (app->configuration.bufferSize)
+			checkBufferSizeFor64BitAddressing += app->configuration.bufferSize[i];
+		else {
+			checkBufferSizeFor64BitAddressing = app->configuration.size[0] * app->configuration.size[1] * app->configuration.size[2] * 8;
+			if (app->configuration.coordinateFeatures > 0) checkBufferSizeFor64BitAddressing *= app->configuration.coordinateFeatures;
+			if (app->configuration.numberBatches > 0) checkBufferSizeFor64BitAddressing *= app->configuration.numberBatches;
+			if (app->configuration.numberKernels > 0) checkBufferSizeFor64BitAddressing *= app->configuration.numberKernels;
+			if (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) checkBufferSizeFor64BitAddressing *= 2;
+			if (app->configuration.quadDoubleDoublePrecision) checkBufferSizeFor64BitAddressing *= 4;
+		}
+	}
+#if(VKFFT_BACKEND==2)
+	app->configuration.useStrict32BitAddress = 0;
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)32)) app->configuration.useStrict32BitAddress = -1;
+#endif
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
+	checkBufferSizeFor64BitAddressing = 0;
+	for (pfUINT i = 0; i < app->configuration.inputBufferNum; i++) {
+		if (app->configuration.inputBufferSize)
+			checkBufferSizeFor64BitAddressing += app->configuration.inputBufferSize[i];
+	}
+#if(VKFFT_BACKEND==2)
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)32)) app->configuration.useStrict32BitAddress = -1;
+#endif
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
+
+	checkBufferSizeFor64BitAddressing = 0;
+	for (pfUINT i = 0; i < app->configuration.outputBufferNum; i++) {
+		if (app->configuration.outputBufferSize)
+			checkBufferSizeFor64BitAddressing += app->configuration.outputBufferSize[i];
+	}
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
+
+	checkBufferSizeFor64BitAddressing = 0;
+	for (pfUINT i = 0; i < app->configuration.kernelNum; i++) {
+		if (app->configuration.kernelSize)
+			checkBufferSizeFor64BitAddressing += app->configuration.kernelSize[i];
+	}
+#if(VKFFT_BACKEND==2)
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)32)) app->configuration.useStrict32BitAddress = -1;
+	// No reason was found to disable strict 32 bit addressing, so enable it
+	if (app->configuration.useStrict32BitAddress == 0) app->configuration.useStrict32BitAddress = 1;
+#endif
+	if (checkBufferSizeFor64BitAddressing >= (pfUINT)pow((pfUINT)2, (pfUINT)34)) app->configuration.useUint64 = 1;
+	if (inputLaunchConfiguration.useUint64 != 0)	app->configuration.useUint64 = inputLaunchConfiguration.useUint64;
+#if(VKFFT_BACKEND==2)
+	if (inputLaunchConfiguration.useStrict32BitAddress != 0) app->configuration.useStrict32BitAddress = inputLaunchConfiguration.useStrict32BitAddress;
+#endif
+
 	app->firstAxis = 0;
 	app->lastAxis = app->configuration.FFTdim - 1;
 	for (int i = 0; i < app->configuration.FFTdim; i++) {

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -1293,11 +1293,27 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	if (inputLaunchConfiguration.performR2C != 0) {
 		app->configuration.performR2C = inputLaunchConfiguration.performR2C;
 	}
+	for (pfUINT i = 0; i < app->configuration.FFTdim; i++) {
+		if (inputLaunchConfiguration.performR2R[i] != 0) {
+			app->configuration.performR2R[i] = inputLaunchConfiguration.performR2R[i];
+			app->configuration.performDCT = 100;
+			app->configuration.performDST = 200;
+		}
+	}
 	if (inputLaunchConfiguration.performDCT != 0) {
 		app->configuration.performDCT = inputLaunchConfiguration.performDCT;
+
+		for (pfUINT i = 0; i < app->configuration.FFTdim; i++) {
+			app->configuration.performR2R[i] = app->configuration.performDCT;
+		}
 	}
+	
 	if (inputLaunchConfiguration.performDST != 0) {
 		app->configuration.performDST = inputLaunchConfiguration.performDST;
+
+		for (pfUINT i = 0; i < app->configuration.FFTdim; i++) {
+			app->configuration.performR2R[i] = 10 + app->configuration.performDST;
+		}
 	}
 	if (inputLaunchConfiguration.forceCallbackVersionRealTransforms != 0)  app->configuration.forceCallbackVersionRealTransforms = inputLaunchConfiguration.forceCallbackVersionRealTransforms; 
 	

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -33,7 +33,7 @@ static inline VkFFTResult initializeBluesteinAutoPadding(VkFFTApplication* app) 
 	VkFFTResult resFFT = VKFFT_SUCCESS;
 	if (!app->configuration.useCustomBluesteinPaddingPattern) {
 		switch (app->configuration.vendorID) {
-		case 0x10DE://NVIDIA
+		case VKFFT_VENDOR_NVIDIA:
 			if (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) {
 				app->configuration.autoCustomBluesteinPaddingPattern = 49;
 			}
@@ -55,7 +55,7 @@ static inline VkFFTResult initializeBluesteinAutoPadding(VkFFTApplication* app) 
 		app->configuration.paddedSizes = (pfUINT*)malloc(app->configuration.autoCustomBluesteinPaddingPattern * sizeof(pfUINT));
 		if (!app->configuration.paddedSizes) return VKFFT_ERROR_MALLOC_FAILED;
 		switch (app->configuration.vendorID) {
-		case 0x10DE://Nvidia
+		case VKFFT_VENDOR_NVIDIA:
 			if (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) {
 				app->configuration.primeSizes[0] = 17;
 				app->configuration.paddedSizes[0] = 36;
@@ -483,20 +483,20 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	VkPhysicalDeviceProperties physicalDeviceProperties = { 0 };
 	vkGetPhysicalDeviceProperties(app->configuration.physicalDevice[0], &physicalDeviceProperties);
 	app->configuration.maxThreadsNum = physicalDeviceProperties.limits.maxComputeWorkGroupInvocations;
-	if (physicalDeviceProperties.vendorID == 0x8086) app->configuration.maxThreadsNum = 256; //Intel fix
+	if (physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) app->configuration.maxThreadsNum = 256; //Intel fix
 	app->configuration.maxComputeWorkGroupCount[0] = physicalDeviceProperties.limits.maxComputeWorkGroupCount[0];
 	app->configuration.maxComputeWorkGroupCount[1] = physicalDeviceProperties.limits.maxComputeWorkGroupCount[1];
 	app->configuration.maxComputeWorkGroupCount[2] = physicalDeviceProperties.limits.maxComputeWorkGroupCount[2];
 	app->configuration.maxComputeWorkGroupSize[0] = physicalDeviceProperties.limits.maxComputeWorkGroupSize[0];
 	app->configuration.maxComputeWorkGroupSize[1] = physicalDeviceProperties.limits.maxComputeWorkGroupSize[1];
 	app->configuration.maxComputeWorkGroupSize[2] = physicalDeviceProperties.limits.maxComputeWorkGroupSize[2];
-	//if ((physicalDeviceProperties.vendorID == 0x8086) && (!app->configuration.doublePrecision) && (!app->configuration.doublePrecisionFloatMemory)) app->configuration.halfThreads = 1;
+	//if ((physicalDeviceProperties.vendorID == VKFFT_VENDOR_INTEL) && (!app->configuration.doublePrecision) && (!app->configuration.doublePrecisionFloatMemory)) app->configuration.halfThreads = 1;
 	app->configuration.sharedMemorySize = physicalDeviceProperties.limits.maxComputeSharedMemorySize;
 	app->configuration.vendorID = physicalDeviceProperties.vendorID;
 	if (inputLaunchConfiguration.pipelineCache != 0)	app->configuration.pipelineCache = inputLaunchConfiguration.pipelineCache;
 	app->configuration.useRaderUintLUT = 1;
 	switch (physicalDeviceProperties.vendorID) {
-	case 0x10DE://NVIDIA
+	case VKFFT_VENDOR_NVIDIA:
 		app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 64 : 32;//the coalesced memory is equal to 32 bytes between L2 and VRAM.
 		app->configuration.useLUT = (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 1 : -1;
 		app->configuration.warpSize = 32;
@@ -505,7 +505,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 		app->configuration.registerBoost4Step = 1;
 		app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision) ? 4194305 : 4194305;
 		break;
-	case 0x8086://INTEL
+	case VKFFT_VENDOR_INTEL:
 		app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 128 : 64;
 		app->configuration.useLUT = 1;
 		app->configuration.warpSize = 32;
@@ -514,7 +514,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 		app->configuration.registerBoost4Step = 1;
 		app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 262144 : 524288;
 		break;
-	case 0x1002://AMD
+	case VKFFT_VENDOR_AMD:
 		app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 64 : 32;
 		app->configuration.useLUT = (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 1 : -1;
 		app->configuration.warpSize = 64;
@@ -649,7 +649,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.registerBoost = 1;
 	app->configuration.registerBoost4Step = 1;
 	app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 4194305 : 4194305;
-	app->configuration.vendorID = 0x10DE;
+	app->configuration.vendorID = VKFFT_VENDOR_NVIDIA;
 #elif(VKFFT_BACKEND==2)
 	hipError_t res = hipSuccess;
 	if (inputLaunchConfiguration.device == 0) {
@@ -754,7 +754,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.registerBoost = 1;
 	app->configuration.registerBoost4Step = 1;
 	app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 1048576 : 2097152;
-	app->configuration.vendorID = 0x1002;
+	app->configuration.vendorID = VKFFT_VENDOR_AMD;
 #elif(VKFFT_BACKEND==3)
 	cl_int res = 0;
 	if (inputLaunchConfiguration.device == 0) {
@@ -807,7 +807,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.maxComputeWorkGroupCount[0] = UINT64_MAX;
 	app->configuration.maxComputeWorkGroupCount[1] = UINT64_MAX;
 	app->configuration.maxComputeWorkGroupCount[2] = UINT64_MAX;
-	//if ((vendorID == 0x8086) && (!app->configuration.doublePrecision) && (!app->configuration.doublePrecisionFloatMemory)) app->configuration.halfThreads = 1;
+	//if ((vendorID == VKFFT_VENDOR_INTEL) && (!app->configuration.doublePrecision) && (!app->configuration.doublePrecisionFloatMemory)) app->configuration.halfThreads = 1;
 	cl_ulong sharedMemorySize;
 	res = clGetDeviceInfo(app->configuration.device[0], CL_DEVICE_LOCAL_MEM_SIZE, sizeof(cl_ulong), &sharedMemorySize, 0);
 	if (res != 0) {
@@ -818,7 +818,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.vendorID = vendorID;
 	app->configuration.useRaderUintLUT = 1;
 	switch (vendorID) {
-	case 0x10DE://NVIDIA
+	case VKFFT_VENDOR_NVIDIA:
 		app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 64 : 32;//the coalesced memory is equal to 32 bytes between L2 and VRAM.
 		app->configuration.useLUT = (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 1 : -1;
 		app->configuration.warpSize = 32;
@@ -828,7 +828,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 		app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 4194305 : 4194305;
 		app->configuration.sharedMemorySize -= 0x10;//reserved by system
 		break;
-	case 0x8086://INTEL
+	case VKFFT_VENDOR_INTEL:
 		app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 128 : 64;
 		app->configuration.useLUT = 1;
 		app->configuration.warpSize = 32;
@@ -837,7 +837,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 		app->configuration.registerBoost4Step = 1;
 		app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 262144 : 524288;
 		break;
-	case 0x1002://AMD
+	case VKFFT_VENDOR_AMD:
 		app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 64 : 32;
 		app->configuration.useLUT = (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 1 : -1;
 		app->configuration.warpSize = 64;
@@ -889,7 +889,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.maxComputeWorkGroupCount[0] = compute_properties.maxGroupCountX;
 	app->configuration.maxComputeWorkGroupCount[1] = compute_properties.maxGroupCountY;
 	app->configuration.maxComputeWorkGroupCount[2] = compute_properties.maxGroupCountZ;
-	//if ((vendorID == 0x8086) && (!app->configuration.doublePrecision) && (!app->configuration.doublePrecisionFloatMemory)) app->configuration.halfThreads = 1;
+	//if ((vendorID == VKFFT_VENDOR_INTEL) && (!app->configuration.doublePrecision) && (!app->configuration.doublePrecisionFloatMemory)) app->configuration.halfThreads = 1;
 	app->configuration.sharedMemorySize = compute_properties.maxSharedLocalMemory;
 
 	app->configuration.coalescedMemory = (app->configuration.halfPrecision) ? 128 : 64;
@@ -899,7 +899,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	app->configuration.registerBoost = (app->configuration.sharedMemorySize >= 65536) ? 1 : 2;
 	app->configuration.registerBoost4Step = 1;
 	app->configuration.swapTo3Stage4Step = (app->configuration.doublePrecision || app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) ? 262144 : 524288;
-	app->configuration.vendorID = 0x8086;
+	app->configuration.vendorID = VKFFT_VENDOR_INTEL;
 	app->configuration.useRaderUintLUT = 1;
 #elif(VKFFT_BACKEND==5)
 	if (inputLaunchConfiguration.device == 0) {
@@ -1212,10 +1212,10 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	} else{
 			app->configuration.fixMinRaderPrimeMult = 17;
 			switch (app->configuration.vendorID) {
-			case 0x10DE://NVIDIA
+			case VKFFT_VENDOR_NVIDIA:
 					app->configuration.fixMaxRaderPrimeMult = 89;
 					break;
-			case 0x1002://AMD profile
+			case VKFFT_VENDOR_AMD:
 					app->configuration.fixMaxRaderPrimeMult = 89;
 					break;
 			default:
@@ -1227,7 +1227,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 	if (inputLaunchConfiguration.fixMaxRaderPrimeMult != 0) app->configuration.fixMaxRaderPrimeMult = inputLaunchConfiguration.fixMaxRaderPrimeMult;
 
 	switch (app->configuration.vendorID) {
-	case 0x1002://AMD profile
+	case VKFFT_VENDOR_AMD:
 			if (app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory)
 					app->configuration.fixMinRaderPrimeFFT = 19;
 			else if (app->configuration.doublePrecision || app->configuration.doublePrecisionFloatMemory)

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_RunApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_RunApp.h
@@ -118,7 +118,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                 pfUINT maxCoordinate = ((app->configuration.matrixConvolution > 1) && (app->configuration.performConvolution) && (app->configuration.FFTdim == 1) && (l == 0)) ? 1 : app->configuration.coordinateFeatures;
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
                 if (l == 0) {
@@ -163,7 +163,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                     pfUINT maxCoordinate = ((app->configuration.matrixConvolution > 1) && (app->configuration.performConvolution) && (app->configuration.FFTdim == 1)) ? 1 : app->configuration.coordinateFeatures;
 #if(VKFFT_BACKEND==0)
                     vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                    vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                    if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                     pfUINT dispatchBlock[3];
                     if (l == 0) {
@@ -210,7 +210,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                 
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
                 
@@ -242,7 +242,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                         
 #if(VKFFT_BACKEND==0)
                         vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                        vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                        if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                         pfUINT dispatchBlock[3];
                         dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan->actualFFTSizePerAxis[i][0] / (double)axis->axisBlock[0] * app->localFFTPlan->actualFFTSizePerAxis[i][i] / (double)axis->specializationConstants.fftDim.data.i);
@@ -270,7 +270,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                         
 #if(VKFFT_BACKEND==0)
                         vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                        vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                        if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                         pfUINT dispatchBlock[3];
                         
@@ -297,7 +297,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                             if (resFFT != VKFFT_SUCCESS) return resFFT;
 #if(VKFFT_BACKEND==0)
                             vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                            vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                            if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                             pfUINT dispatchBlock[3];
                             dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan->actualFFTSizePerAxis[i][0] / (double)axis->axisBlock[0] * app->localFFTPlan->actualFFTSizePerAxis[i][i] / (double)axis->specializationConstants.fftDim.data.i);
@@ -334,7 +334,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                     vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                    vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                    if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                     pfUINT dispatchBlock[3];
                     dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[i][0] / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[i][i] / (double)axis->specializationConstants.fftDim.data.i);
@@ -360,7 +360,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
 
@@ -388,7 +388,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
                 if (i==1){
@@ -445,7 +445,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
                 dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[0][0] / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[0][1] / (double)axis->specializationConstants.fftDim.data.i);
@@ -476,7 +476,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                     vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                    vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                    if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                     pfUINT dispatchBlock[3];
                     dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[i][0]  / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[i][i] / (double)axis->specializationConstants.fftDim.data.i);
@@ -504,7 +504,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                         if (resFFT != VKFFT_SUCCESS) return resFFT;
 #if(VKFFT_BACKEND==0)
                         vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                        vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                        if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                         pfUINT dispatchBlock[3];
                         dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[i][0]  / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[i][i] / (double)axis->specializationConstants.fftDim.data.i);
@@ -534,7 +534,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
 
@@ -563,7 +563,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                 if (resFFT != VKFFT_SUCCESS) return resFFT;
 #if(VKFFT_BACKEND==0)
                 vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                 pfUINT dispatchBlock[3];
                 if (l == 0) {
@@ -608,7 +608,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
 
 #if(VKFFT_BACKEND==0)
                     vkCmdBindPipeline(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipeline);
-                    vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
+                    if (!app->configuration.usePushDescriptors) vkCmdBindDescriptorSets(app->configuration.commandBuffer[0], VK_PIPELINE_BIND_POINT_COMPUTE, axis->pipelineLayout, 0, 1, &axis->descriptorSet, 0, 0);
 #endif
                     pfUINT dispatchBlock[3];
                     if (l == 0) {

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_RunApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_RunApp.h
@@ -339,7 +339,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                     pfUINT dispatchBlock[3];
                     dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[i][0] / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[i][i] / (double)axis->specializationConstants.fftDim.data.i);
                     dispatchBlock[1] = 1;
-                    dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberKernels;
+                    dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberBatches * app->configuration.numberKernels;
                     for (int p = 1; p <app->configuration.FFTdim; p++){
                         if (p != i)
                             dispatchBlock[2]*= app->localFFTPlan_inverse->actualFFTSizePerAxis[i][p];
@@ -372,7 +372,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                 
                 
                 dispatchBlock[1] = 1;
-                dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberKernels;
+                dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberBatches * app->configuration.numberKernels;
                 resFFT = VkFFT_DispatchPlan(app, axis, dispatchBlock);
                 if (resFFT != VKFFT_SUCCESS) return resFFT;
                 printDebugInformation(app, axis);
@@ -412,7 +412,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                         dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[0][0] / axis->specializationConstants.fftDim.data.i / (double)axis->axisBlock[0]);
                         dispatchBlock[1] = app->localFFTPlan_inverse->actualFFTSizePerAxis[0][1];
                     }
-                    dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberKernels;
+                    dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberBatches * app->configuration.numberKernels;
                     for (int p = 2; p <app->configuration.FFTdim; p++){
                         dispatchBlock[2]*= app->localFFTPlan_inverse->actualFFTSizePerAxis[i-1][p];
                     }
@@ -420,7 +420,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                 }else{
                     dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[i-1][0] / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[i-1][i-1] / (double)axis->specializationConstants.fftDim.data.i);
                     dispatchBlock[1] = 1;
-                    dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberKernels;
+                    dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberBatches * app->configuration.numberKernels;
                     for (int p = 1; p <app->configuration.FFTdim; p++){
                         if (p != (i-1))
                             dispatchBlock[2]*= app->localFFTPlan_inverse->actualFFTSizePerAxis[i-1][p];
@@ -450,7 +450,7 @@ static inline VkFFTResult VkFFTAppend(VkFFTApplication* app, int inverse, VkFFTL
                 pfUINT dispatchBlock[3];
                 dispatchBlock[0] = (pfUINT)pfceil(app->localFFTPlan_inverse->actualFFTSizePerAxis[0][0] / (double)axis->axisBlock[0] * app->localFFTPlan_inverse->actualFFTSizePerAxis[0][1] / (double)axis->specializationConstants.fftDim.data.i);
                 dispatchBlock[1] = 1;
-                dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberKernels;
+                dispatchBlock[2] = app->configuration.coordinateFeatures * app->configuration.numberBatches * app->configuration.numberKernels;
                 
                 //if (app->configuration.mergeSequencesR2C == 1) dispatchBlock[0] = (pfUINT)pfceil(dispatchBlock[0] / 2.0);
                 //if (app->configuration.performZeropadding[2]) dispatchBlock[2] = (pfUINT)pfceil(dispatchBlock[2] / 2.0);

--- a/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
+++ b/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
@@ -282,6 +282,8 @@ static inline void appendKernelConvolution(VkFFTSpecializationConstantsLayout* s
 
 				PfAdd(sc, &sc->inoutID_y, &sc->inoutID_y, &sc->shiftY);
 
+				temp_int.data.i = batching_localSize.data.i;
+
 				if ((sc->size[1].data.i % temp_int.data.i) != 0) {
 #if (VKFFT_BACKEND!=2) //AMD compiler fix
 					PfIf_lt_start(sc, &sc->inoutID_y, &sc->size[1]);

--- a/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
+++ b/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
@@ -361,7 +361,7 @@ static inline void appendKernelOffset(VkFFTSpecializationConstantsLayout* sc, in
                 PfMod(sc, &sc->inoutID_y, &sc->tempInt, &sc->size[i]);
                 checkZeropad_otherAxes(sc, &sc->inoutID_y, i);
                 PfMul(sc, &sc->inoutID_y, &sc->inoutID_y, &bufferStride[locStrideOrder], 0);
-                PfAdd(sc, &sc->shiftZ, &sc->shiftZ, &sc->inoutID_y);
+                PfAdd(sc, &sc->blockInvocationID, &sc->blockInvocationID, &sc->inoutID_y);
 				if ((i!=(sc->numFFTdims-1) && (sc->axis_id != (sc->numFFTdims-1))) || ((i!=(sc->numFFTdims-2)) && (sc->axis_id == (sc->numFFTdims-1))))
 					PfDiv(sc, &sc->tempInt, &sc->tempInt, &sc->size[i]);
                 locStrideOrder++;

--- a/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
+++ b/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/vkFFT_ReadWrite.h
@@ -381,7 +381,7 @@ static inline void appendKernelOffset(VkFFTSpecializationConstantsLayout* sc, in
 		PfMul(sc, &temp_int, &sc->coordinate, &bufferStride[sc->numFFTdims], 0);
 		PfAdd(sc, &sc->blockInvocationID, &sc->blockInvocationID, &temp_int);
 	}
-	if ((sc->numBatches.data.i > 1) || (sc->numKernels.data.i > 1)) {
+	if (((sc->numBatches.data.i > 1) && (!sc->singleKernelMultipleBatches)) || (sc->numKernels.data.i > 1)) {
 		if (sc->convolutionStep && (sc->numKernels.data.i > 1)) {
 			PfMul(sc, &sc->tempInt, &sc->batchID, &sc->inputStride[sc->numFFTdims+1], 0);
 			PfAdd(sc, &sc->blockInvocationID, &sc->blockInvocationID, &sc->tempInt);

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_CompileKernel.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_CompileKernel.h
@@ -728,7 +728,7 @@ static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* 
 	}
 	if (app->configuration.saveApplicationToString) {
 		size_t codeSize;
-		res = clGetProgramInfo(axis->program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &codeSize, NULL);
+		res = clGetProgramInfo(axis->program, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &codeSize, 0);
 		if (res != CL_SUCCESS) {
 			free(code0);
 			code0 = 0;
@@ -743,7 +743,7 @@ static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* 
 			deleteVkFFT(app);
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
-		res = clGetProgramInfo(axis->program, CL_PROGRAM_BINARIES, sizeof(unsigned char*), &axis->binary, NULL);
+		res = clGetProgramInfo(axis->program, CL_PROGRAM_BINARIES, sizeof(unsigned char*), &axis->binary, 0);
 		if (res != CL_SUCCESS) {
 			if (app->configuration.saveApplicationToString) {
 				free(axis->binary);

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_ManageMemory.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_ManageMemory.h
@@ -141,7 +141,7 @@ static inline VkFFTResult VkFFT_TransferDataFromCPU(VkFFTApplication* app, void*
 	cl_mem* buffer = (cl_mem*)input_buffer;
 	cl_command_queue commandQueue = clCreateCommandQueue(app->configuration.context[0], app->configuration.device[0], 0, &res);
 	if (res != CL_SUCCESS) return VKFFT_ERROR_FAILED_TO_CREATE_COMMAND_QUEUE;
-	res = clEnqueueWriteBuffer(commandQueue, buffer[0], CL_TRUE, 0, transferSize, cpu_arr, 0, NULL, NULL);
+	res = clEnqueueWriteBuffer(commandQueue, buffer[0], CL_TRUE, 0, transferSize, cpu_arr, 0, 0, 0);
 	if (res != CL_SUCCESS) {
 		return VKFFT_ERROR_FAILED_TO_COPY;
 	}
@@ -265,7 +265,7 @@ static inline VkFFTResult VkFFT_TransferDataToCPU(VkFFTApplication* app, void* c
 	cl_mem* buffer = (cl_mem*)output_buffer;
 	cl_command_queue commandQueue = clCreateCommandQueue(app->configuration.context[0], app->configuration.device[0], 0, &res);
 	if (res != CL_SUCCESS) return VKFFT_ERROR_FAILED_TO_CREATE_COMMAND_QUEUE;
-	res = clEnqueueReadBuffer(commandQueue, buffer[0], CL_TRUE, 0, transferSize, cpu_arr, 0, NULL, NULL);
+	res = clEnqueueReadBuffer(commandQueue, buffer[0], CL_TRUE, 0, transferSize, cpu_arr, 0, 0, 0);
 	if (res != CL_SUCCESS) {
 		return VKFFT_ERROR_FAILED_TO_COPY;
 	}

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_AxisBlockSplitter.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_AxisBlockSplitter.h
@@ -125,7 +125,7 @@ static inline VkFFTResult VkFFTSplitAxisBlock(VkFFTApplication* app, VkFFTPlan* 
 				if ((scale > 1) && ((axis->specializationConstants.fftDim.data.i * axis->groupedBatch * scale <= maxSequenceLengthSharedMemory))) axis->groupedBatch *= scale;
 
 				axis->axisBlock[0] = ((pfUINT)axis->specializationConstants.stageStartSize.data.i > axis->groupedBatch) ? axis->groupedBatch : (pfUINT)axis->specializationConstants.stageStartSize.data.i;
-				if (app->configuration.vendorID == 0x10DE) {
+				if (app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) {
 					while ((axis->axisBlock[1] * axis->axisBlock[0] >= 2 * app->configuration.aimThreads) && (axis->axisBlock[0] > maxBatchCoalesced)) {
 						axis->axisBlock[0] /= 2;
 						if (axis->axisBlock[0] < maxBatchCoalesced) axis->axisBlock[0] = maxBatchCoalesced;
@@ -209,7 +209,7 @@ static inline VkFFTResult VkFFTSplitAxisBlock(VkFFTApplication* app, VkFFTPlan* 
 	//axis->groupedBatch = 8;
 	//shared memory bank conflict resolve
 //#if(VKFFT_BACKEND!=2)//for some reason, hip doesn't get performance increase from having variable shared memory strides.
-	if (app->configuration.vendorID == 0x10DE) {
+	if (app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) {
 		if (FFTPlan->numAxisUploads[axis_id] == 2) {
 			if ((axis_upload_id > 0) || (axis->specializationConstants.fftDim.data.i <= 512)) {
 				if ((pfUINT)(axis->specializationConstants.fftDim.data.i * (64 / axis->specializationConstants.complexSize)) <= maxSequenceLengthSharedMemory) {
@@ -327,7 +327,7 @@ static inline VkFFTResult VkFFTSplitAxisBlock(VkFFTApplication* app, VkFFTPlan* 
 				r2cmult = 1;
 			}
 			if ((FFTPlan->numAxisUploads[0] == 1) && ((pfUINT)pfceil(FFTPlan->actualFFTSizePerAxis[axis_id][1] / (double)r2cmult) < axis->axisBlock[1])) axis->axisBlock[1] = (pfUINT)pfceil(FFTPlan->actualFFTSizePerAxis[axis_id][1] / (double)r2cmult);
-			if (app->configuration.vendorID == 0x10DE) {
+			if (app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) {
 				while ((axis->axisBlock[1] * axis->axisBlock[0] >= 2 * app->configuration.aimThreads) && (axis->axisBlock[1] > maxBatchCoalesced)) {
 					axis->axisBlock[1] /= 2;
 					if (axis->axisBlock[1] < maxBatchCoalesced) axis->axisBlock[1] = maxBatchCoalesced;
@@ -394,7 +394,7 @@ static inline VkFFTResult VkFFTSplitAxisBlock(VkFFTApplication* app, VkFFTPlan* 
 			if ((scale > 1) && ((axis->specializationConstants.fftDim.data.i * axis->groupedBatch * scale <= maxSequenceLengthSharedMemory))) axis->groupedBatch *= scale;
 
 			axis->axisBlock[0] = ((pfUINT)axis->specializationConstants.stageStartSize.data.i > axis->groupedBatch) ? axis->groupedBatch : axis->specializationConstants.stageStartSize.data.i;
-			if (app->configuration.vendorID == 0x10DE) {
+			if (app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) {
 				while ((axis->axisBlock[1] * axis->axisBlock[0] >= 2 * app->configuration.aimThreads) && (axis->axisBlock[0] > maxBatchCoalesced)) {
 					axis->axisBlock[0] /= 2;
 					if (axis->axisBlock[0] < maxBatchCoalesced) axis->axisBlock[0] = maxBatchCoalesced;
@@ -444,7 +444,7 @@ static inline VkFFTResult VkFFTSplitAxisBlock(VkFFTApplication* app, VkFFTPlan* 
 		}
 
 		axis->axisBlock[0] = (FFTPlan->actualFFTSizePerAxis[axis_id][0] > axis->groupedBatch) ? axis->groupedBatch : FFTPlan->actualFFTSizePerAxis[axis_id][0];
-		if (app->configuration.vendorID == 0x10DE) {
+		if (app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) {
 			while ((axis->axisBlock[1] * axis->axisBlock[0] >= 2 * app->configuration.aimThreads) && (axis->axisBlock[0] > maxBatchCoalesced)) {
 				axis->axisBlock[0] /= 2;
 				if (axis->axisBlock[0] < maxBatchCoalesced) axis->axisBlock[0] = maxBatchCoalesced;

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
@@ -132,9 +132,9 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			free(phaseVectors_fp128);
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
-		pfUINT phaseVectorsNonZeroSize = ((((app->configuration.performDCT == 4) || (app->configuration.performDST == 4)) && (app->configuration.size[axis_id] % 2 == 0)) || ((FFTPlan->bigSequenceEvenR2C) && (axis_id == 0))) ? app->configuration.size[axis_id] / 2 : app->configuration.size[axis_id];
-		if (app->configuration.performDCT == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] - 2;
-		if (app->configuration.performDST == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] + 2;
+		pfUINT phaseVectorsNonZeroSize = ((((FFTPlan->axes[axis_id][0].specializationConstants.performDCT == 4) || (FFTPlan->axes[axis_id][0].specializationConstants.performDST == 4)) && (app->configuration.size[axis_id] % 2 == 0)) || ((FFTPlan->bigSequenceEvenR2C) && (axis_id == 0))) ? app->configuration.size[axis_id] / 2 : app->configuration.size[axis_id];
+		if (FFTPlan->axes[axis_id][0].specializationConstants.performDCT == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] - 2;
+		if (FFTPlan->axes[axis_id][0].specializationConstants.performDST == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] + 2;
 		pfLD double_PI = pfFPinit("3.14159265358979323846264338327950288419716939937510");
 		for (pfUINT i = 0; i < FFTPlan->actualFFTSizePerAxis[axis_id][axis_id]; i++) {
 			pfUINT rm = (i * i) % (2 * phaseVectorsNonZeroSize);
@@ -305,9 +305,9 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			deleteVkFFT(&kernelPreparationApplication);
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
-		pfUINT phaseVectorsNonZeroSize = ((((app->configuration.performDCT == 4) || (app->configuration.performDST == 4)) && (app->configuration.size[axis_id] % 2 == 0)) || ((FFTPlan->bigSequenceEvenR2C) && (axis_id == 0))) ? app->configuration.size[axis_id] / 2 : app->configuration.size[axis_id];
-		if (app->configuration.performDCT == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] - 2;
-		if (app->configuration.performDST == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] + 2;
+		pfUINT phaseVectorsNonZeroSize = ((((FFTPlan->axes[axis_id][0].specializationConstants.performDCT == 4) || (FFTPlan->axes[axis_id][0].specializationConstants.performDST == 4)) && (app->configuration.size[axis_id] % 2 == 0)) || ((FFTPlan->bigSequenceEvenR2C) && (axis_id == 0))) ? app->configuration.size[axis_id] / 2 : app->configuration.size[axis_id];
+		if (FFTPlan->axes[axis_id][0].specializationConstants.performDCT == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] - 2;
+		if (FFTPlan->axes[axis_id][0].specializationConstants.performDST == 1) phaseVectorsNonZeroSize = 2 * app->configuration.size[axis_id] + 2;
 		if ((FFTPlan->numAxisUploads[axis_id] > 1) && (!app->configuration.makeForwardPlanOnly)) {
 			if (app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory) {
 				PfContainer in = VKFFT_ZERO_INIT;

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_Scheduler.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_Scheduler.h
@@ -2237,7 +2237,7 @@ static inline VkFFTResult VkFFTScheduler(VkFFTApplication* app, VkFFTPlan* FFTPl
 			else
 				complexSize = (2 * sizeof(float));
 	}
-	int usedSharedMemory = (((app->configuration.size[axis_id] & (app->configuration.size[axis_id] - 1)) == 0) && (!app->configuration.performDCT) && (!app->configuration.performDST)) ? (int)app->configuration.sharedMemorySizePow2 : (int)app->configuration.sharedMemorySize;
+	int usedSharedMemory = (((app->configuration.size[axis_id] & (app->configuration.size[axis_id] - 1)) == 0) && (!app->configuration.performR2R[axis_id])) ? (int)app->configuration.sharedMemorySizePow2 : (int)app->configuration.sharedMemorySize;
 	int maxSequenceLengthSharedMemory = usedSharedMemory / complexSize;
 	int maxSingleSizeNonStrided = maxSequenceLengthSharedMemory;
 
@@ -2268,13 +2268,13 @@ static inline VkFFTResult VkFFTScheduler(VkFFTApplication* app, VkFFTPlan* FFTPl
 			FFTPlan->bigSequenceEvenR2C = 1;
 		}
 	}
-	if (app->configuration.performDCT == 1) {
+	if (app->configuration.performR2R[axis_id] == 1) {
 		FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] = 2 * app->configuration.size[axis_id] - 2; // now in actualFFTSize - modified dimension size for R2C/DCT
 	}
-	if (app->configuration.performDST == 1) {
+	if (app->configuration.performR2R[axis_id] == 11) {
 		FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] = 2 * app->configuration.size[axis_id] + 2; // now in actualFFTSize - modified dimension size for R2C/DCT
 	}
-	if (((app->configuration.performDCT == 4) || (app->configuration.performDST == 4)) && (app->configuration.size[axis_id] % 2 == 0)) {
+	if (((app->configuration.performR2R[axis_id] == 4) || (app->configuration.performR2R[axis_id] == 14)) && (app->configuration.size[axis_id] % 2 == 0)) {
 		FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] = app->configuration.size[axis_id] / 2; // now in actualFFTSize - modified dimension size for R2C/DCT
 		//FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] = app->configuration.size[axis_id] * 8; // now in actualFFTSize - modified dimension size for R2C/DCT
 	}
@@ -2890,14 +2890,6 @@ static inline VkFFTResult VkFFTScheduler(VkFFTApplication* app, VkFFTPlan* FFTPl
 	if (numPasses > 3) {
 		//printf("sequence length exceeds boundaries\n");
 		return VKFFT_ERROR_UNSUPPORTED_FFT_LENGTH;
-	}
-	if ((numPasses > 1) && ((app->configuration.performDCT > 0) || (app->configuration.performDST > 0))) {
-		//printf("sequence length exceeds boundaries\n");
-		//return VKFFT_ERROR_UNSUPPORTED_FFT_LENGTH_R2R;
-	}
-	if ((numPasses > 1) && (app->configuration.performR2C > 0) && (axis_id == 0) && (app->configuration.size[axis_id] % 2 != 0)) {
-		//printf("sequence length exceeds boundaries\n");
-		//return VKFFT_ERROR_UNSUPPORTED_FFT_LENGTH_R2C;
 	}
 	pfUINT tempBufferSize = 0;
 	if ((app->configuration.performR2C) && (axis_id == 0)) {

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_Scheduler.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_Scheduler.h
@@ -2653,7 +2653,7 @@ static inline VkFFTResult VkFFTScheduler(VkFFTApplication* app, VkFFTPlan* FFTPl
 		locAxisSplit[0] = FFTPlan->actualFFTSizePerAxis[axis_id][axis_id];
 	}
 	if (numPasses == 2) {
-		if (isPowOf2 && (!((app->configuration.vendorID == 0x10DE) && (FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] > 262144)))) {
+		if (isPowOf2 && (!((app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) && (FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] > 262144)))) {
 			if ((axis_id == nonStridedAxisId) && ((!app->configuration.reorderFourStep) || (app->useBluesteinFFT[axis_id]))) {
 				int maxPow8SharedMemory = (int)pow(8, ((int)log2(maxSequenceLengthSharedMemory)) / 3);
 				//unit stride
@@ -2749,7 +2749,7 @@ static inline VkFFTResult VkFFTScheduler(VkFFTApplication* app, VkFFTPlan* FFTPl
 		}
 	}
 	if (numPasses == 3) {
-		if (isPowOf2 && (!((app->configuration.vendorID == 0x10DE) && (FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] > 262144)))) {
+		if (isPowOf2 && (!((app->configuration.vendorID == VKFFT_VENDOR_NVIDIA) && (FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] > 262144)))) {
 			int maxPow8Strided = (int)pow(8, ((int)log2(maxSingleSizeStrided)) / 3);
 			if ((axis_id == nonStridedAxisId) && ((!app->configuration.reorderFourStep) || (app->useBluesteinFFT[axis_id]))) {
 				//unit stride

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
@@ -150,16 +150,16 @@ static inline VkFFTResult VkFFTPlanAxis(VkFFTApplication* app, VkFFTPlan* FFTPla
 		axis->specializationConstants.useBluesteinFFT = 1;
 	}
 
-	if ((app->configuration.performDCT == 3) || (app->configuration.performDST == 3)) {
+	if ((app->configuration.performR2R[axis_id] == 3) || (app->configuration.performR2R[axis_id] == 13)) {
 		axis->specializationConstants.actualInverse = (int)inverse;
 		axis->specializationConstants.inverse = (int)!inverse;
 	}
 	else {
-		if ((app->configuration.performDCT == 4) || (app->configuration.performDST == 4)) {
+		if ((app->configuration.performR2R[axis_id] == 4) || (app->configuration.performR2R[axis_id] == 14)) {
 			axis->specializationConstants.actualInverse = (int)inverse;
 			axis->specializationConstants.inverse = 1;
 		}
-		else if ((app->configuration.performDCT == 1) || (app->configuration.performDST == 1)) {
+		else if ((app->configuration.performR2R[axis_id] == 1) || (app->configuration.performR2R[axis_id] == 11)) {
 			axis->specializationConstants.actualInverse = (int)inverse;
 			axis->specializationConstants.inverse = 0;
 		}
@@ -171,14 +171,14 @@ static inline VkFFTResult VkFFTPlanAxis(VkFFTApplication* app, VkFFTPlan* FFTPla
 	if (app->useBluesteinFFT[axis_id]) {
 		axis->specializationConstants.actualInverse = (int)inverse;
 		axis->specializationConstants.inverse = (int)reverseBluesteinMultiUpload;
-		if ((app->configuration.performDCT == 3) || (app->configuration.performDST == 3)) {
+		if ((app->configuration.performR2R[axis_id] == 3) || (app->configuration.performR2R[axis_id] == 13)) {
 			axis->specializationConstants.inverseBluestein = (int)!inverse;
 		}
 		else {
-			if ((app->configuration.performDCT == 4) || (app->configuration.performDST == 4)) {
+			if ((app->configuration.performR2R[axis_id] == 4) || (app->configuration.performR2R[axis_id] == 14)) {
 				axis->specializationConstants.inverseBluestein = 1;
 			}
-			else if ((app->configuration.performDCT == 1) || (app->configuration.performDST == 1)) {
+			else if ((app->configuration.performR2R[axis_id] == 1) || (app->configuration.performR2R[axis_id] == 11)) {
 				axis->specializationConstants.inverseBluestein = 0;
 			}
 			else {
@@ -204,10 +204,10 @@ static inline VkFFTResult VkFFTPlanAxis(VkFFTApplication* app, VkFFTPlan* FFTPla
 	axis->specializationConstants.performR2C = (int)FFTPlan->actualPerformR2CPerAxis[axis_id];
 	axis->specializationConstants.performR2CmultiUpload = ((axis->specializationConstants.performR2C || (FFTPlan->bigSequenceEvenR2C)) && (axis->specializationConstants.numAxisUploads > 1)) ? 1 : 0;
 	
-	if (app->configuration.performDCT > 0)
-		axis->specializationConstants.performDCT = (int)app->configuration.performDCT;
-	if (app->configuration.performDST > 0)
-		axis->specializationConstants.performDST = (int)app->configuration.performDST;
+	if ((app->configuration.performR2R[axis_id] > 0) && (app->configuration.performR2R[axis_id] < 10))
+		axis->specializationConstants.performDCT = (int)app->configuration.performR2R[axis_id];
+	if (app->configuration.performR2R[axis_id] > 10)
+		axis->specializationConstants.performDST = (int)app->configuration.performR2R[axis_id] - 10;
 
 	axis->specializationConstants.performR2RmultiUpload = (((axis->specializationConstants.performDCT>0) || (axis->specializationConstants.performDST>0)) && (axis->specializationConstants.numAxisUploads > 1)) ? 1 : 0;
 	if (axis->specializationConstants.performR2C || axis->specializationConstants.performDCT || axis->specializationConstants.performDST) axis->specializationConstants.forceCallbackVersionRealTransforms = app->configuration.forceCallbackVersionRealTransforms;

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
@@ -281,7 +281,7 @@ static inline VkFFTResult VkFFTPlanAxis(VkFFTApplication* app, VkFFTPlan* FFTPla
 
 	axisStride[app->configuration.FFTdim+1].type = 31;
 	axisStride[app->configuration.FFTdim+1].data.i = axisStride[app->configuration.FFTdim].data.i * app->configuration.coordinateFeatures;
-	if ((FFTPlan->numAxisUploads[axis_id] > 1) && ((app->useBluesteinFFT[axis_id] && (!((axis_upload_id == FFTPlan->numAxisUploads[axis_id] - 1) && (reverseBluesteinMultiUpload == 0))))) || ((!app->useBluesteinFFT[axis_id]) && (!((axis_upload_id == FFTPlan->numAxisUploads[axis_id] - 1))))) {
+	if ((FFTPlan->numAxisUploads[axis_id] > 1) && ((app->useBluesteinFFT[axis_id] && (!((axis_upload_id == FFTPlan->numAxisUploads[axis_id] - 1) && (reverseBluesteinMultiUpload == 0)))) || ((!app->useBluesteinFFT[axis_id]) && (!(axis_upload_id == FFTPlan->numAxisUploads[axis_id] - 1))))) {
 		axisStride[0].data.i = 1;
         pfINT prevStride = axisStride[0].data.i;
         

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
@@ -210,7 +210,7 @@ static inline VkFFTResult VkFFTPlanAxis(VkFFTApplication* app, VkFFTPlan* FFTPla
 		axis->specializationConstants.performDST = (int)app->configuration.performR2R[axis_id] - 10;
 
 	axis->specializationConstants.performR2RmultiUpload = (((axis->specializationConstants.performDCT>0) || (axis->specializationConstants.performDST>0)) && (axis->specializationConstants.numAxisUploads > 1)) ? 1 : 0;
-	if (axis->specializationConstants.performR2C || axis->specializationConstants.performDCT || axis->specializationConstants.performDST) axis->specializationConstants.forceCallbackVersionRealTransforms = app->configuration.forceCallbackVersionRealTransforms;
+	if (axis->specializationConstants.performR2C || axis->specializationConstants.performDCT || axis->specializationConstants.performDST) axis->specializationConstants.forceCallbackVersionRealTransforms = (int)app->configuration.forceCallbackVersionRealTransforms;
 	if (((axis->specializationConstants.performR2C && (!FFTPlan->bigSequenceEvenR2C)) || axis->specializationConstants.performDCT || axis->specializationConstants.performDST) && (axis->specializationConstants.numAxisUploads > 1)) axis->specializationConstants.forceCallbackVersionRealTransforms = 1;
 	//if ((axis->specializationConstants.performR2CmultiUpload) && (app->configuration.size[0] % 2 != 0)) return VKFFT_ERROR_UNSUPPORTED_FFT_LENGTH_R2C;
 	//pfUINT passID = FFTPlan->numAxisUploads[axis_id] - 1 - axis_upload_id;

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_FFT.h
@@ -474,6 +474,7 @@ static inline VkFFTResult VkFFTPlanAxis(VkFFTApplication* app, VkFFTPlan* FFTPla
 
 		axis->specializationConstants.numCoordinates = (app->configuration.matrixConvolution > 1) ? 1 : (int)app->configuration.coordinateFeatures;
 		axis->specializationConstants.matrixConvolution = (int)app->configuration.matrixConvolution;
+		axis->specializationConstants.singleKernelMultipleBatches = (int)app->configuration.singleKernelMultipleBatches;
 		axis->specializationConstants.coordinate.type = 31;
 		axis->specializationConstants.coordinate.data.i = 0;
 		axis->specializationConstants.batchID.type = 31;

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_R2C.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_Plans/vkFFT_Plan_R2C.h
@@ -195,6 +195,8 @@ static inline VkFFTResult VkFFTPlanR2CMultiUploadDecomposition(VkFFTApplication*
 
 		axis->specializationConstants.numCoordinates = (app->configuration.matrixConvolution > 1) ? 1 : (int)app->configuration.coordinateFeatures;
 		axis->specializationConstants.matrixConvolution = (int)app->configuration.matrixConvolution;
+		axis->specializationConstants.singleKernelMultipleBatches = (int)app->configuration.singleKernelMultipleBatches;
+		
         for (pfUINT i = 0; i < VKFFT_MAX_FFT_DIMENSIONS; i++) {
             axis->specializationConstants.size[i].type = 31;
             axis->specializationConstants.size[i].data.i = (pfINT)app->configuration.size[i];

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -34,7 +34,7 @@
 #include <inttypes.h>
 #if(VKFFT_BACKEND==0)
 #include "vulkan/vulkan.h"
-#include "glslang_c_interface.h"
+#include "glslang/Include/glslang_c_interface.h"
 #elif(VKFFT_BACKEND==1)
 #include <nvrtc.h>
 #include <cuda.h>

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -104,6 +104,7 @@ typedef struct {
 	VkCommandPool* commandPool;//pointer to Vulkan command pool, created with vkCreateCommandPool
 	VkFence* fence;//pointer to Vulkan fence, created with vkCreateFence
 	pfUINT isCompilerInitialized;//specify if glslang compiler has been intialized before (0 - off, 1 - on). Default 0
+	pfUINT usePushDescriptors;//specify if push descriptors have been enabled on the device - then all descriptor sets updates at VkFFTAppend call will be issued with push descriptors. (0 - off, 1 - on). Default 0
 #elif(VKFFT_BACKEND==1)
 	CUdevice* device;//pointer to CUDA device, obtained from cuDeviceGet
 	//CUcontext* context;//pointer to CUDA context, obtained from cuDeviceGet

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -90,6 +90,13 @@ struct PfContainer{
 	int size; //  bytes allcoated in name
 };
 
+typedef enum VkFFTVendor : pfUINT
+{
+	VKFFT_VENDOR_AMD    = 0x1002,
+	VKFFT_VENDOR_INTEL  = 0x8086,
+	VKFFT_VENDOR_NVIDIA = 0x10DE
+} VkFFTVendor;
+
 typedef struct {
 	//WHDCN layout
 
@@ -303,7 +310,7 @@ typedef struct {
 	pfINT maxTempLength; //specify how big can be buffer used for intermediate string sprintfs be (in char). Default 5000 chars. If code segfaults for some reason - try increasing this number.
 	pfUINT autoCustomBluesteinPaddingPattern; // default value for useCustomBluesteinPaddingPattern
 	pfUINT useRaderUintLUT; // allocate additional LUT to store g_pow
-	pfUINT vendorID; // vendorID 0x10DE - NVIDIA, 0x8086 - Intel, 0x1002 - AMD, etc.
+	VkFFTVendor vendorID; // vendorID
 #if(VKFFT_BACKEND==0)
 	VkDeviceMemory tempBufferDeviceMemory;//Filled at app creation
 	VkCommandBuffer* commandBuffer;//Filled at app execution

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -274,6 +274,7 @@ typedef struct {
 	pfUINT matrixConvolution; //if equal to 2 perform 2x2, if equal to 3 perform 3x3 matrix-vector convolution. Overrides coordinateFeatures
 	pfUINT symmetricKernel; //specify if kernel in 2x2 or 3x3 matrix convolution is symmetric
 	pfUINT numberKernels;// N - only used in convolution step - specify how many kernels were initialized before. Expands one input to multiple (batched) output
+	pfUINT singleKernelMultipleBatches;// 0 off, 1 - perform convolution with one kernel to multiple (numberBatches) input/output. kernel can still use multiple coordinates for batching (for example if you want to have 3 kernels cycling for 9 systems). Default 0
 	pfUINT kernelConvolution;// specify if this application is used to create kernel for convolution, so it has the same properties. performConvolution has to be set to 0 for kernel creation
 
 	//register overutilization (experimental): (default 0 if not stated otherwise)
@@ -802,6 +803,7 @@ typedef struct {
 	pfUINT kernelBlockSize;
 	int numCoordinates;
 	int matrixConvolution; //if equal to 2 perform 2x2, if equal to 3 perform 3x3 matrix-vector convolution. Overrides coordinateFeatures
+	int singleKernelMultipleBatches;
 	PfContainer numBatches;
 	PfContainer numKernels;
 	int conjugateConvolution;

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -212,8 +212,10 @@ typedef struct {
 	pfUINT doublePrecisionFloatMemory; //use FP64 precision for all calculations, while all memory storage is done in FP32.
 
 	pfUINT performR2C; //perform R2C/C2R decomposition (0 - off, 1 - on)
-	pfUINT performDCT; //perform DCT transformation (X - DCT type, 1-4)
-	pfUINT performDST; //perform DST transformation (X - DCT type, 1-4)
+	pfUINT performDCT; //perform DCT transformation of the same type for all axes (X - DCT type, 1-4)
+	pfUINT performDST; //perform DST transformation of the same type for all axes (X - DST type, 1-4)
+	pfUINT performR2R[VKFFT_MAX_FFT_DIMENSIONS]; //set DCT/DST transformation per axis (0 - off, 1 for DCT-I, 2 for DCT-II, 3 for DCT-III, 4 for DCT-IV, 11 for DST-I, 12 for DST-II, 13 for DST-III, 14 for DST-IV). Overwritten by performDCT and performDST, if they are not 0.
+
 	pfUINT disableMergeSequencesR2C; //disable merging of two real sequences to reduce calculations (0 - off, 1 - on)
 	pfUINT forceCallbackVersionRealTransforms; //force callback version of R2C and R2R algorithms for all usecases (0 - off, 1 - on)
 


### PR DESCRIPTION
This pull request introduces `VkFFTVendor` enum datatype for vendor id instead of using magic values. It is based on the same datatype as `streamID` member was.