### PR TITLE
Add forward declarations and typedefs for exposed structures

### DIFF
--- a/vkFFT/vkFFT-fwd.h
+++ b/vkFFT/vkFFT-fwd.h
@@ -1,0 +1,36 @@
+// This file is part of VkFFT, a Vulkan Fast Fourier Transform library
+//
+// Copyright (C) 2020 - present Dmitrii Tolmachev <dtolm96@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef VKFFT_FWD_H
+#define VKFFT_FWD_H
+
+// Forward declarations
+struct VkFFTConfiguration;
+struct VkFFTLaunchParams;
+struct VkFFTApplication;
+
+// Typedefs
+typedef struct VkFFTConfiguration VkFFTConfiguration;
+typedef struct VkFFTLaunchParams VkFFTLaunchParams;
+typedef struct VkFFTApplication VkFFTApplication;
+
+#endif // VKFFT_FWD_H

--- a/vkFFT/vkFFT.h
+++ b/vkFFT/vkFFT.h
@@ -101,6 +101,7 @@
 
 #endif
 
+#include "vkFFT-fwd.h"
 #include "vkFFT/vkFFT_Structs/vkFFT_Structs.h"
 #include "vkFFT/vkFFT_AppManagement/vkFFT_RunApp.h"
 #include "vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h"

--- a/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
+++ b/vkFFT/vkFFT/vkFFT_Structs/vkFFT_Structs.h
@@ -90,7 +90,7 @@ struct PfContainer{
 	int size; //  bytes allcoated in name
 };
 
-typedef struct {
+struct VkFFTConfiguration {
 	//WHDCN layout
 
 	//required parameters:
@@ -342,9 +342,9 @@ typedef struct {
 	MTL::CommandBuffer* commandBuffer;//Filled at app execution
 	MTL::ComputeCommandEncoder* commandEncoder;//Filled at app execution
 #endif
-} VkFFTConfiguration;//parameters specified at plan creation
+};//parameters specified at plan creation
 
-typedef struct {
+struct VkFFTLaunchParams {
 #if(VKFFT_BACKEND==0)
 	VkCommandBuffer* commandBuffer;//commandBuffer to which FFT is appended
 
@@ -404,7 +404,7 @@ typedef struct {
 	pfUINT inputBufferOffsetImaginary;//specify if VkFFT has to offset the first element position inside the input buffer. In bytes. Default 0 
 	pfUINT outputBufferOffsetImaginary;//specify if VkFFT has to offset the first element position inside the output buffer. In bytes. Default 0
 	pfUINT kernelOffsetImaginary;//specify if VkFFT has to offset the first element position inside the kernel. In bytes. Default 0
-} VkFFTLaunchParams;//parameters specified at plan execution
+};//parameters specified at plan execution
 typedef enum VkFFTResult {
 	VKFFT_SUCCESS = 0,
 	VKFFT_ERROR_MALLOC_FAILED = 1,
@@ -1186,7 +1186,7 @@ typedef struct {
 	VkFFTAxis R2Cdecomposition;
 	VkFFTAxis inverseBluesteinAxes[VKFFT_MAX_FFT_DIMENSIONS][4];
 } VkFFTPlan;
-typedef struct {
+struct VkFFTApplication {
 	VkFFTConfiguration configuration;
 	VkFFTPlan* localFFTPlan;
 	VkFFTPlan* localFFTPlan_inverse; //additional inverse plan
@@ -1246,6 +1246,6 @@ typedef struct {
 
 	pfUINT applicationStringSize;//size of saveApplicationString in bytes
 	void* saveApplicationString;//memory array(uint32_t* for Vulkan, char* for CUDA/HIP/OpenCL) through which user can access VkFFT generated binaries. (will be allocated by VkFFT, deallocated with deleteVkFFT call)
-} VkFFTApplication;
+};
 
 #endif


### PR DESCRIPTION
This PR introduces `vkFFT-fwd.h` module that includes forward declarations and typedef of user exposed structures. The goal is to reduce the compilation times when including VkFFT in a header file. It does not contain any backend dependent code, thus is independent on the selected backend completely.

After this change, this behaviour is possible:
```cpp
// Class.hpp
#include <memory>
#include <vkFFT-fwd.h>

class Class
{
public:
  // ...
private:
  struct VkFFTApplicationDeleter;

  // This works
  VkFFTApplication* mAppPtr{};

  // This also works
  std::unique_ptr<VkFFTApplication, VkFFTApplicationDeleter> mAppUniquePtr{};

  // Fails to compile as it would require require the backend dependent VkFFTApplication struct definition
  // VkFFTApplication mApp{};
};
```
```cpp
// Class.cpp
#define VKFFT_BACKEND 1
#include <vkFFT.h>

struct Class::VkFFTApplicationDeleter
{
  void operator()(VkFFTApplication* app)
  {
    deleteVkFFT(app);
  }
};

// ...
```
