### PR TITLE
Fix incorrect code generation for performConvolution with radix on strided axis

### DIFF
--- a/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
+++ b/vkFFT/vkFFT/vkFFT_CodeGen/vkFFT_KernelsLevel1/PrePostProcessing/vkFFT_Convolution.h
@@ -429,9 +429,8 @@ static inline void appendKernelConvolution(VkFFTSpecializationConstantsLayout* s
 			temp_int1.data.i = (i + 1) * sc->localSize[1].data.i;
 
 			if (temp_int1.data.i > sc->fftDim.data.i) {
-				//&sc->tempIntLen = sprintf(&sc->tempIntStr, "		if(%s < %" PRIu64 "){\n", &sc->gl_LocalInvocationID_y, &sc->fftDim - (i + k * used_registers) * &sc->localSize[1]);
-				temp_int1.data.i = sc->localSize[1].data.i - (temp_int1.data.i - sc->fftDim.data.i);
-				PfIf_lt_start(sc, &sc->gl_LocalInvocationID_y, &temp_int1);
+				PfIf_end(sc);
+				PfIf_end(sc);
 			}
 		}
 	}

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_Scheduler.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_Scheduler.h
@@ -1033,6 +1033,9 @@ static inline VkFFTResult VkFFTScheduler(VkFFTApplication* app, VkFFTPlan* FFTPl
 	if ((FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] >= app->configuration.swapTo2Stage4Step) && (numPasses < 3)) numPasses = 2;//Force set to 2 stage 4 step algorithm
 	if ((FFTPlan->actualFFTSizePerAxis[axis_id][axis_id] >= app->configuration.swapTo3Stage4Step) && (app->configuration.swapTo3Stage4Step >= 65536)) numPasses = 3;//Force set to 3 stage 4 step algorithm
 	if (forceRaderTwoUpload && (numPasses == 1)) numPasses = 2;//Force set Rader cases that use more than 512 or maxNumThreads threads per one of Rader primes
+	if (app->configuration.performConvolution && (numPasses > 1) && (axis_id != (int)nonStridedAxisId)) {
+		numPasses = 1;
+	}
 	pfUINT* locAxisSplit = FFTPlan->axisSplit[axis_id];
 	if (numPasses == 1) {
 		locAxisSplit[0] = FFTPlan->actualFFTSizePerAxis[axis_id][axis_id];


### PR DESCRIPTION
Fixes unclosed if statements for strided axis when radix is used in performConvolution=1, see issue  #222 