### PR TITLE
Metal backend: don't release autoreleased objects

### DIFF
--- a/VkFFT_TestSuite.cpp
+++ b/VkFFT_TestSuite.cpp
@@ -293,6 +293,7 @@ VkFFTResult launchVkFFT(VkGPU* vkGPU, uint64_t sample_id, bool file_output, FILE
     vkGPU->device = device;
     MTL::CommandQueue* queue = device->newCommandQueue();
     vkGPU->queue = queue;
+    auto *pool = NS::AutoreleasePool::alloc()->init();
 #endif
 
 	uint64_t isCompilerInitialized = 1;
@@ -527,6 +528,7 @@ VkFFTResult launchVkFFT(VkGPU* vkGPU, uint64_t sample_id, bool file_output, FILE
     vkGPU->queue->release();
     vkGPU->device->release();
     devices->release();
+    pool->drain();
 #endif
 
 	return resFFT;

--- a/benchmark_scripts/vkFFT_scripts/src/utils_VkFFT.cpp
+++ b/benchmark_scripts/vkFFT_scripts/src/utils_VkFFT.cpp
@@ -507,8 +507,6 @@ VkFFTResult transferDataToCPU(VkGPU* vkGPU, void* cpu_arr, void* output_buffer, 
 	blitCommandEncoder->endEncoding();
 	copyCommandBuffer->commit();
 	copyCommandBuffer->waitUntilCompleted();
-	blitCommandEncoder->release();
-	copyCommandBuffer->release();
 	memcpy(cpu_arr, stagingBuffer->contents(), transferSize);
 	stagingBuffer->release();
 #endif
@@ -632,8 +630,6 @@ VkFFTResult transferDataFromCPU(VkGPU* vkGPU, void* cpu_arr, void* input_buffer,
 	blitCommandEncoder->endEncoding();
 	copyCommandBuffer->commit();
 	copyCommandBuffer->waitUntilCompleted();
-	blitCommandEncoder->release();
-	copyCommandBuffer->release();
 	stagingBuffer->release();
 #endif
 	return resFFT;
@@ -894,9 +890,6 @@ VkFFTResult performVulkanFFT(VkGPU* vkGPU, VkFFTApplication* app, VkFFTLaunchPar
 	commandBuffer->waitUntilCompleted();
 	std::chrono::steady_clock::time_point timeEnd = std::chrono::steady_clock::now();
 	double totTime = std::chrono::duration_cast<std::chrono::microseconds>(timeEnd - timeSubmit).count() * 0.001;
-
-	commandEncoder->release();
-	commandBuffer->release();
 #endif
 	return resFFT;
 }
@@ -1031,8 +1024,6 @@ VkFFTResult performVulkanFFTiFFT(VkGPU* vkGPU, VkFFTApplication* app, VkFFTLaunc
 	std::chrono::steady_clock::time_point timeEnd = std::chrono::steady_clock::now();
 	double totTime = std::chrono::duration_cast<std::chrono::microseconds>(timeEnd - timeSubmit).count() * 0.001;
 	time_result[0] = totTime / num_iter;
-	commandEncoder->release();
-	commandBuffer->release();
 #endif
 	return resFFT;
 }

--- a/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
+++ b/vkFFT/vkFFT/vkFFT_AppManagement/vkFFT_InitializeApp.h
@@ -1126,9 +1126,7 @@ static inline VkFFTResult setConfigurationVkFFT(VkFFTApplication* app, VkFFTConf
 
 	dummy_state->release();
 	function->release();
-	str_name->release();
 	dummy_library->release();
-	str_code->release();
 	compileOptions->release();
 #endif
 

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_CompileKernel.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_CompileKernel.h
@@ -23,6 +23,48 @@
 #define VKFFT_COMPILEKERNEL_H
 #include "vkFFT/vkFFT_Structs/vkFFT_Structs.h"
 
+#if(VKFFT_BACKEND==1)
+
+// Get architecture for CUDA compilation.
+// arch_out holds the architecture to pass to the compiler
+// use_cubin indicates whether to get the code in CUBIN or PTX format
+static void getCudaArchitecture(VkFFTApplication *app, int *arch_out, bool *use_cubin) {
+        int count = 1;
+        nvrtcGetNumSupportedArchs(&count);
+        int *supportedArchs = (int *)malloc(count * sizeof(int));
+
+        int maxSupported = 0;
+        if (nvrtcGetSupportedArchs(supportedArchs) == cudaSuccess) {
+                for (int i = 0; i < count; i++) {
+                        int a = supportedArchs[i];
+                        if (a > maxSupported) {
+                                maxSupported = a;
+                        }
+                }
+                int target = 10 * app->configuration.computeCapabilityMajor
+                             + app->configuration.computeCapabilityMinor;
+                if (target > maxSupported) {
+                        // If target architecture is not supported, compile
+                        // for the maximum supported architecture, and use
+                        // PTX for forward compatibility
+                        *use_cubin = false;
+                        *arch_out = maxSupported;
+                        return;
+                } else {
+                        // Otherwise compile for the target architecture, and
+                        // use CUBIN
+                        *use_cubin = true;
+                        *arch_out = target;
+                        return;
+                }
+        }
+
+        free(supportedArchs);
+        *arch_out = 0;
+        *use_cubin = false;
+}
+#endif
+
 static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* axis) {
 #if(VKFFT_BACKEND==0)
 	VkResult res = VK_SUCCESS;
@@ -331,17 +373,21 @@ static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* 
 		}
 		int numOpts = 1;
 		char* opts[5];
-		opts[0] = (char*)malloc(sizeof(char) * 50);
+		opts[0] = (char*)malloc(sizeof(char) * 60);
 		if (!opts[0]) {
 			free(code0);
 			code0 = 0;
 			deleteVkFFT(app);
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
+
+                int arch;
+                bool use_cubin;
+                getCudaArchitecture(app, &arch, &use_cubin);
 #if (CUDA_VERSION >= 11030)
-		sprintf(opts[0], "--gpu-architecture=sm_%" PRIu64 "%" PRIu64 "", app->configuration.computeCapabilityMajor, app->configuration.computeCapabilityMinor);
+		sprintf(opts[0], "--gpu-architecture=sm_%d", arch);
 #else
-		sprintf(opts[0], "--gpu-architecture=compute_%" PRIu64 "%" PRIu64 "", app->configuration.computeCapabilityMajor, app->configuration.computeCapabilityMinor);
+		sprintf(opts[0], "--gpu-architecture=compute_%d", arch);
 #endif
 		if (app->configuration.quadDoubleDoublePrecision || app->configuration.quadDoubleDoublePrecisionDoubleMemory){
 			opts[1] = (char*)malloc(sizeof(char) * 50);
@@ -385,17 +431,22 @@ static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* 
 				return VKFFT_ERROR_FAILED_TO_COMPILE_PROGRAM;
 			}
 		}
-#if (CUDA_VERSION >= 11030)
-		result = nvrtcGetCUBINSize(prog, &codeSize);
-#else
-		result = nvrtcGetPTXSize(prog, &codeSize);
-#endif
+
+                if (use_cubin) {
+                        result = nvrtcGetCUBINSize(prog, &codeSize);
+                } else {
+                        result = nvrtcGetPTXSize(prog, &codeSize);
+                }
+
 		if (result != NVRTC_SUCCESS) {
-#if (CUDA_VERSION >= 11030)
-			printf("nvrtcGetCUBINSize error: %s\n", nvrtcGetErrorString(result));
-#else
-			printf("nvrtcGetPTXSize error: %s\n", nvrtcGetErrorString(result));
-#endif
+                        if (use_cubin) {
+                                printf("nvrtcGetCUBINSize error: %s\n",
+                                       nvrtcGetErrorString(result));
+                        } else {
+                                printf("nvrtcGetPTXSize error: %s\n",
+                                       nvrtcGetErrorString(result));
+                        }
+
 			free(code0);
 			code0 = 0;
 			deleteVkFFT(app);
@@ -410,17 +461,21 @@ static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* 
 			return VKFFT_ERROR_MALLOC_FAILED;
 		}
 		axis->binary = code;
-#if (CUDA_VERSION >= 11030)
-		result = nvrtcGetCUBIN(prog, code);
-#else
+                if (use_cubin) {
+                        result = nvrtcGetCUBIN(prog, code);
+                } else {
 		result = nvrtcGetPTX(prog, code);
-#endif
+                }
+
 		if (result != NVRTC_SUCCESS) {
-#if (CUDA_VERSION >= 11030)
-			printf("nvrtcGetCUBIN error: %s\n", nvrtcGetErrorString(result));
-#else
-			printf("nvrtcGetPTX error: %s\n", nvrtcGetErrorString(result));
-#endif
+                        if (use_cubin) {
+                                printf("nvrtcGetCUBIN error: %s\n",
+                                       nvrtcGetErrorString(result));
+                        } else {
+                                printf("nvrtcGetPTX error: %s\n",
+                                       nvrtcGetErrorString(result));
+                        }
+
 			free(code);
 			code = 0;
 			free(code0);

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_CompileKernel.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_CompileKernel.h
@@ -956,14 +956,12 @@ static inline VkFFTResult VkFFT_CompileKernel(VkFFTApplication* app, VkFFTAxis* 
 		if (app->configuration.saveApplicationToString) {
 
 		}
-		str->release();
 	}
 	//const char function_name[20] = "VkFFT_main_R2C";
 	NS::String* str = NS::String::string(axis->VkFFTFunctionName, NS::UTF8StringEncoding);
 	MTL::Function* function = axis->library->newFunction(str);
 	axis->pipeline = app->configuration.device->newComputePipelineState(function, &error);
 	function->release();
-	str->release();
 #endif
 	return VKFFT_SUCCESS;
 }

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_ManageMemory.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_API_handles/vkFFT_ManageMemory.h
@@ -183,8 +183,6 @@ static inline VkFFTResult VkFFT_TransferDataFromCPU(VkFFTApplication* app, void*
 	blitCommandEncoder->endEncoding();
 	copyCommandBuffer->commit();
 	copyCommandBuffer->waitUntilCompleted();
-	blitCommandEncoder->release();
-	copyCommandBuffer->release();
 	stagingBuffer->release();
 #endif
 	return resFFT;
@@ -307,8 +305,6 @@ static inline VkFFTResult VkFFT_TransferDataToCPU(VkFFTApplication* app, void* c
 	blitCommandEncoder->endEncoding();
 	copyCommandBuffer->commit();
 	copyCommandBuffer->waitUntilCompleted();
-	blitCommandEncoder->release();
-	copyCommandBuffer->release();
 	memcpy(cpu_arr, stagingBuffer->contents(), transferSize);
 	stagingBuffer->release();
 #endif

--- a/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
+++ b/vkFFT/vkFFT/vkFFT_PlanManagement/vkFFT_HostFunctions/vkFFT_RecursiveFFTGenerators.h
@@ -539,8 +539,6 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandEncoder->endEncoding();
 			commandBuffer->commit();
 			commandBuffer->waitUntilCompleted();
-			commandEncoder->release();
-			commandBuffer->release();
 #endif
 		}
 		if ((FFTPlan->numAxisUploads[axis_id] > 1) && (!app->configuration.makeForwardPlanOnly)) {
@@ -946,8 +944,6 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandEncoder->endEncoding();
 			commandBuffer->commit();
 			commandBuffer->waitUntilCompleted();
-			commandEncoder->release();
-			commandBuffer->release();
 		}
 		if ((FFTPlan->numAxisUploads[axis_id] == 1) && (!app->configuration.makeForwardPlanOnly)) {
 			MTL::CommandBuffer* commandBuffer = app->configuration.queue->commandBuffer();
@@ -967,8 +963,6 @@ static inline VkFFTResult VkFFTGeneratePhaseVectors(VkFFTApplication* app, VkFFT
 			commandEncoder->endEncoding();
 			commandBuffer->commit();
 			commandBuffer->waitUntilCompleted();
-			commandEncoder->release();
-			commandBuffer->release();
 		}
 #endif
 #if(VKFFT_BACKEND==0)
@@ -1358,8 +1352,6 @@ static inline VkFFTResult VkFFTGenerateRaderFFTKernel(VkFFTApplication* app, VkF
 				commandEncoder->endEncoding();
 				commandBuffer->commit();
 				commandBuffer->waitUntilCompleted();
-				commandEncoder->release();
-				commandBuffer->release();
 #endif
 				resFFT = VkFFT_TransferDataToCPU(&kernelPreparationApplication, axis->specializationConstants.raderContainer[i].raderFFTkernel, &bufferRaderFFT, bufferSize);
 				if (resFFT != VKFFT_SUCCESS) {


### PR DESCRIPTION
Fixes #226 

Note that after this change, applications which use the Metal backend, but do not use an autorelease pool, will leak memory. So it could break some existing applications.